### PR TITLE
Introduce parser for strings combining dice groups and numbers

### DIFF
--- a/app/utils/dice-group.ts
+++ b/app/utils/dice-group.ts
@@ -1,29 +1,39 @@
 import Die from 'multiattack-5e/utils/die';
 
 export default class DiceGroup {
-    numDice: number
-    die: Die
+    numDice: number;
+    die: Die;
+    add: boolean;
 
-    constructor(numDice: number, numSides: number) {
+    constructor(numDice: number, numSides: number, add = true) {
         if (numDice < 0) {
-            throw new Error("Number of dice in group must be non-negative")
+            throw new Error("Number of dice in group must be non-negative");
         }
 
-        this.numDice = numDice
-        this.die = new Die(numSides)
+        this.numDice = numDice;
+        this.die = new Die(numSides);
+        this.add = add;
     }
 
+    /**
+     * Roll all of the dice in this group (which are identical to each other) and return the total
+     * 
+     * @returns the total from rolling all of the dice in this group
+     */
     roll(): number {
-        /**
-         * Roll all of the dice in this group (which are identical to
-         * each other) and return the total
-         * 
-         * @returns the total from rolling all of the dice in this group
-         */
-        let total = 0
+
+        let total = 0;
         for (let i = 0; i < this.numDice; i++) {
-            total += this.die.roll()
+            total += this.die.roll();
         }
-        return total
+        return total;
+    }
+
+    /**
+     * Indicate whether this group should be added or subtracted from a total; for instance, if an attack's damage is described as "2d6 - 1d4", 2d6 would return "true" and 1d4 would return "false".
+     * @returns true if this group should be added to a total; false if this should be subtracted from the total
+     */
+    shouldAdd(): boolean {
+        return this.add;
     }
 }

--- a/app/utils/dice-string-parser.ts
+++ b/app/utils/dice-string-parser.ts
@@ -1,0 +1,56 @@
+import DiceGroup from "./dice-group"
+
+export interface DiceGroupsAndNumber {
+    diceGroups: Array<DiceGroup>
+    modifier: number
+}
+
+export default class DiceStringParser {
+    // Matches a string containing only one or more instances of dice groups (eg 2d6) or numbers added or subtracted from each other. The string cannot contain any other entries. Every entry must be preceded by "+" or "-" except for the first term, where the sign is optional. Note that this regex cannot be marked with "g" or it will preserve state between different strings and incorrectly mark some as not matching.
+    diceStringRegex = /^(?: *[+-]? *(?:\d+d\d+)|\d+)(?: *[+-] *(?:(?:\d+d\d+)|\d+))*$/i;
+
+    // Matches a dice group or number with an optional sign. This uses "g" to enable parsing many terms out of the same expression; the code makes sure to consume all possible matches each time it is used.
+    termRegex = /(?: *(?<sign>[+-]?) *(?:(?:(?<numDice>\d+)d(?<numSides>\d+))|(?<number>\d+)))/gi;
+
+    /**
+     * Parses a combination of dice groups and numbers, such as the string used to describe damage in D&D 5e, into a series of dice-group classes and the total modifier described by these numbers.
+     * @param diceString a string describing one or more dice groups (eg 2d6) or numbers which are added to or subtracted from each other
+     * @returns the list of described dice groups and all of the numbers added together into a single modifier
+     */
+    parse(diceString: string): DiceGroupsAndNumber {
+        // Check that the string matches the overall expected pattern, with no additional text or missing signs
+        if (!this.diceStringRegex.test(diceString)) {
+            throw new Error("Unable to parse dice groups or constants from input string");
+        }
+
+        // Extract the dice groups and/or constant modifier one term at a time
+        let described: DiceGroupsAndNumber = {
+            diceGroups: [],
+            modifier: 0
+        };
+        let match = this.termRegex.exec(diceString);
+        while (match) {
+            if (!match.groups) {
+                throw new Error("Unexpectedly unable to find groups in match (regex constructed incorrectly?)");
+            }
+
+            // If the sign is unset, assume that the term should be added
+            let add = !match.groups["sign"] || match.groups["sign"] == "+";
+
+            if (match.groups["number"]) {
+                let sign = add ? 1 : -1;
+                described.modifier += sign * Number(match.groups["number"]);
+            } else {
+                described.diceGroups.push(
+                    new DiceGroup(
+                        Number(match.groups["numDice"]),
+                        Number(match.groups["numSides"]),
+                        add));
+            }
+
+            // Extract the next term from the string
+            match = this.termRegex.exec(diceString);
+        }
+        return described;
+    }
+}

--- a/tests/unit/utils/dice-group-test.ts
+++ b/tests/unit/utils/dice-group-test.ts
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import DiceGroup from 'multiattack-5e/utils/dice-group';
 import sinon from 'sinon';
 
-module('Unit | Models | dice-group', function (hooks) {
+module('Unit | Utils | dice-group', function (hooks) {
   setupTest(hooks);
 
   test('it rejects invalid input values', async function (assert) {
@@ -27,14 +27,16 @@ module('Unit | Models | dice-group', function (hooks) {
     let group1d8 = new DiceGroup(1, 8);
     assert.equal(group1d8.numDice, 1, "group should have expected number of dice");
     assert.equal(group1d8.die.sides, 8, "group's die should have expected number of sides");
+    assert.true(group1d8.shouldAdd(), "dice group should be added by default");
 
     group1d8.die.roll = sinon.fake.returns(3);
     assert.equal(group1d8.roll(), 3, "roll of a single die should return expected sum");
 
     // Create a group with multiple dice and mock them
-    let group3d6 = new DiceGroup(3, 6);
+    let group3d6 = new DiceGroup(3, 6, false);
     assert.equal(group3d6.numDice, 3, "group should have expected number of dice");
     assert.equal(group3d6.die.sides, 6, "group's dice should have expected number of sides");
+    assert.false(group3d6.shouldAdd(), "dice group should track whether to add value to a larger total");
 
     let fakeDie = sinon.stub();
     fakeDie.onCall(0).returns(3);

--- a/tests/unit/utils/dice-string-parser-test.ts
+++ b/tests/unit/utils/dice-string-parser-test.ts
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DiceStringParser, { DiceGroupsAndNumber } from 'multiattack-5e/utils/dice-string-parser';
+import DiceGroup from 'multiattack-5e/utils/dice-group';
+
+module('Unit | Utils | dice-string-parser', function (hooks) {
+    setupTest(hooks);
+
+    test('it rejects invalid strings', async function (assert) {
+        let invalidStrings = [
+            "d6+4",
+            "3 d5-10",
+            "1d6?6",
+            "4d5_0",
+            "3d 5-10",
+            "text 1d4+4",
+            "2d6-1 following",
+            "+2d6 5d8"
+        ];
+
+        for (const invalid of invalidStrings) {
+            assert.throws(
+                () => new DiceStringParser().parse(invalid),
+                new Error("Unable to parse dice groups or constants from input string"),
+                `invalid string ${invalid} should be rejected`
+            );
+        }
+    });
+
+    test('it parses valid strings', async function (assert) {
+        const valid: Map<string, DiceGroupsAndNumber> = new Map();
+        valid.set("1d6+4", {
+            diceGroups: [new DiceGroup(1, 6)], modifier: 4
+        });
+        valid.set("11d12-10", {
+            diceGroups: [new DiceGroup(11, 12)], modifier: -10
+        });
+        valid.set("4d8 + 1", {
+            diceGroups: [new DiceGroup(4, 8)], modifier: 1
+        });
+        valid.set("+3d5-10+1 + 2 - 1d4", {
+            diceGroups: [new DiceGroup(3, 5), new DiceGroup(1, 4, false)], modifier: -7
+        });
+        valid.set("3d5", {
+            diceGroups: [new DiceGroup(3, 5)], modifier: 0
+        });
+        valid.set("-2d6", {
+            diceGroups: [new DiceGroup(2, 6, false)], modifier: 0
+        });
+        valid.set("40", {
+            diceGroups: [], modifier: 40
+        });
+
+        let parser = new DiceStringParser()
+        for (const [dmgStr, expected] of valid) {
+            try {
+                assert.deepEqual(parser.parse(dmgStr), expected, `${dmgStr} should parse to expected value`);
+            } catch (error) {
+                assert.true(false, `Unexpected error thrown for ${dmgStr}: ${error}`);
+            }
+        }
+    });
+});

--- a/tests/unit/utils/die-test.ts
+++ b/tests/unit/utils/die-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Die from 'multiattack-5e/utils/die';
 
-module('Unit | Models | die', function (hooks) {
+module('Unit | Utils | die', function (hooks) {
   setupTest(hooks);
 
   test('it rejects invalid numbers of sides', async function (assert) {


### PR DESCRIPTION
This introduces a parser for strings consisting of groups of dice and numbers added or subtracted from one another. Attack and damage information in systems like D&D 5e is represented in this format (eg "1d20 + 5 - 1d6" for an attack roll affected by Synaptic Static or "1d6 + 3 + 3d8" for a paladin's attack and smite). Parsing these strings into a series of dice groups and a constant will allow users to type in attack details in a familiar format.