### PR TITLE
Add utility class representing a damage type

### DIFF
--- a/app/utils/damage.ts
+++ b/app/utils/damage.ts
@@ -1,0 +1,64 @@
+import DiceStringParser, { DiceGroupsAndModifier } from "./dice-string-parser";
+
+export default class Damage {
+  type: string;
+
+  damageString: string;
+  damage: DiceGroupsAndModifier;
+
+  targetResistant: boolean;
+  targetVulnerable: boolean;
+
+  constructor(
+    damageString: string,
+    type: string,
+    targetResistant = false,
+    targetVulnerable = false
+  ) {
+    this.damage = new DiceStringParser().parse(damageString);
+    this.damageString = damageString;
+    this.type = type;
+    this.targetResistant = targetResistant;
+    this.targetVulnerable = targetVulnerable;
+  }
+
+  /**
+   * Calculate the damage inflicted by an attack described by this class. This
+   * simulates rolling the dice (if applicable) and takes target resistance and
+   * vulnerability into account when finding the total amount of damage
+   * inflicted. If the attack was a critical hit, the number of dice rolled will
+   * be doubled
+   * @param crit: whether this attack was a critical hit
+   * @returns the damage inflicted by an attack described by this class
+   */
+  roll(crit: boolean) {
+    let total = 0;
+
+    // Roll all dice
+    for (const dice of this.damage.diceGroups) {
+      // debugger;
+      const sign = dice.shouldAdd() ? 1 : -1;
+      total += sign * dice.roll();
+
+      if (crit) {
+        total += sign * dice.roll();
+      }
+    }
+
+    total += this.damage.modifier;
+
+    // Reset the total to 0 if it is negative (which may happen due to a
+    // negative damage modifier)
+    total = Math.max(total, 0);
+
+    if (this.targetResistant) {
+      total = Math.floor(total / 2);
+    }
+
+    if (this.targetVulnerable) {
+      total = total * 2;
+    }
+
+    return total;
+  }
+}

--- a/app/utils/dice-string-parser.ts
+++ b/app/utils/dice-string-parser.ts
@@ -1,6 +1,6 @@
 import DiceGroup from './dice-group';
 
-export interface DiceGroupsAndNumber {
+export interface DiceGroupsAndModifier {
   diceGroups: Array<DiceGroup>;
   modifier: number;
 }
@@ -30,7 +30,7 @@ export default class DiceStringParser {
    * @returns the list of described dice groups and all of the numbers added
    * together into a single modifier
    */
-  parse(diceString: string): DiceGroupsAndNumber {
+  parse(diceString: string): DiceGroupsAndModifier {
     // Check that the string matches the overall expected pattern, with no
     // additional text or missing signs
     if (!this.diceStringRegex.test(diceString)) {
@@ -40,7 +40,7 @@ export default class DiceStringParser {
     }
 
     // Extract the dice groups and/or constant modifier one term at a time
-    const described: DiceGroupsAndNumber = {
+    const described: DiceGroupsAndModifier = {
       diceGroups: [],
       modifier: 0,
     };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,4 +18,4 @@ module.exports = function (defaults) {
   });
 
   return app.toTree();
-}
+};

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   env: {
-    embertest: true
-  }
+    embertest: true,
+  },
 };

--- a/tests/unit/utils/damage-test.ts
+++ b/tests/unit/utils/damage-test.ts
@@ -1,0 +1,203 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Damage from 'multiattack-5e/utils/damage';
+import DiceGroup from 'multiattack-5e/utils/dice-group';
+
+module('Unit | Utils | damage', function (hooks) {
+  setupTest(hooks);
+
+  test('it rolls one dice', async function (assert) {
+    const damage = new Damage('1d6 + 1', 'radiant');
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      1,
+      'damage should roll one group of dice'
+    );
+
+    const fake1d6 = sinon.stub();
+    fake1d6.onCall(0).returns(3);
+    const group1d6: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group1d6) {
+      group1d6.die.roll = fake1d6;
+    }
+
+    assert.strictEqual(
+      damage.roll(false),
+      4,
+      'roll should inflict 3 + 1 = 4 total damage'
+    );
+  });
+
+  test('it rolls double dice on a critical hit', async function (assert) {
+    const damage = new Damage('1d6 + 2', 'radiant');
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      1,
+      'damage should roll one group of dice'
+    );
+
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(3);
+    fakeD6.onCall(1).returns(4);
+    const group1d6: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group1d6) {
+      group1d6.die.roll = fakeD6;
+    }
+
+    assert.strictEqual(
+      damage.roll(true),
+      9,
+      'roll should inflict 3 + 4 + 2 = 9 total damage on a critical hit'
+    );
+  });
+
+  test('it rolls and adds multiple dice groups', async function (assert) {
+    const damage = new Damage('3d8 + 1 + 2d6', 'radiant');
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      2,
+      'damage should roll two groups of dice'
+    );
+
+    const fakeD8 = sinon.stub();
+    fakeD8.onCall(0).returns(3);
+    fakeD8.onCall(1).returns(7);
+    fakeD8.onCall(2).returns(5);
+
+    const group3d8: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group3d8) {
+      group3d8.die.roll = fakeD8;
+    }
+
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(1);
+    fakeD6.onCall(1).returns(4);
+
+    const group2d6: DiceGroup | undefined = damage.damage.diceGroups[1];
+    if (group2d6) {
+      group2d6.die.roll = fakeD6;
+    }
+
+    assert.strictEqual(
+      damage.roll(false),
+      21,
+      'roll should inflict (3 + 7 + 5) + (1 + 4) + 1 = 21 total damage'
+    );
+  });
+
+  test('it doubles all dice groups on a critical hit', async function (assert) {
+    const damage = new Damage('3d8 + 2 + 2d6', 'radiant');
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      2,
+      'damage should roll two groups of dice'
+    );
+
+    const fakeD8 = sinon.stub();
+    fakeD8.onCall(0).returns(3);
+    fakeD8.onCall(1).returns(7);
+    fakeD8.onCall(2).returns(5);
+    fakeD8.onCall(3).returns(5);
+    fakeD8.onCall(4).returns(1);
+    fakeD8.onCall(5).returns(2);
+
+    const group3d8: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group3d8) {
+      group3d8.die.roll = fakeD8;
+    }
+
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(1);
+    fakeD6.onCall(1).returns(4);
+    fakeD6.onCall(2).returns(2);
+    fakeD6.onCall(3).returns(2);
+
+    const group2d6: DiceGroup | undefined = damage.damage.diceGroups[1];
+    if (group2d6) {
+      group2d6.die.roll = fakeD6;
+    }
+
+    assert.strictEqual(
+      damage.roll(true),
+      34,
+      'roll should inflict 22 + (5 + 1 + 2) + (2 + 2) = 34 total damage'
+    );
+  });
+
+  test('it halves damage for resistant targets', async function (assert) {
+    const damage = new Damage('2d6 + 1', 'radiant', true);
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      1,
+      'damage should roll one group of dice'
+    );
+
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(3);
+    fakeD6.onCall(1).returns(5);
+    const group2d6: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group2d6) {
+      group2d6.die.roll = fakeD6;
+    }
+
+    assert.strictEqual(
+      damage.roll(false),
+      4,
+      'roll should inflict (3 + 5 + 1) / 2 = 4 total damage'
+    );
+  });
+
+  test('it doubles damage for vulnerable targets', async function (assert) {
+    const damage = new Damage('2d6 + 1', 'radiant', false, true);
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      1,
+      'damage should roll one group of dice'
+    );
+
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(3);
+    fakeD6.onCall(1).returns(5);
+    const group2d6: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group2d6) {
+      group2d6.die.roll = fakeD6;
+    }
+
+    assert.strictEqual(
+      damage.roll(false),
+      18,
+      'roll should inflict (3 + 5 + 1) * 2 = 18 total damage'
+    );
+  });
+
+  test('it halves, then doubles, damage for resistant and vulnerable targets', async function (assert) {
+    const damage = new Damage('2d6 + 1', 'radiant', true, true);
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      1,
+      'damage should roll one group of dice'
+    );
+
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(3);
+    fakeD6.onCall(1).returns(5);
+    const group2d6: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group2d6) {
+      group2d6.die.roll = fakeD6;
+    }
+
+    assert.strictEqual(
+      damage.roll(false),
+      8,
+      'roll should inflict ((3 + 5 + 1) / 2) * 2 = 8 total damage'
+    );
+  });
+});

--- a/tests/unit/utils/dice-string-parser-test.ts
+++ b/tests/unit/utils/dice-string-parser-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import DiceStringParser, {
-  DiceGroupsAndNumber,
+  DiceGroupsAndModifier,
 } from 'multiattack-5e/utils/dice-string-parser';
 import DiceGroup from 'multiattack-5e/utils/dice-group';
 
@@ -31,7 +31,7 @@ module('Unit | Utils | dice-string-parser', function (hooks) {
   });
 
   test('it parses valid strings', async function (assert) {
-    const valid: Map<string, DiceGroupsAndNumber> = new Map();
+    const valid: Map<string, DiceGroupsAndModifier> = new Map();
     valid.set('1d6+4', {
       diceGroups: [new DiceGroup(1, 6)],
       modifier: 4,


### PR DESCRIPTION
This class is useful for calculating the damage of a particular type inflicted by an attack. Since targets may resist some damage types and be vulnerable to others, handling each type as a separate class simplifies damage calculations for attacks which work with multiple damage types.

Although there will be a section of the input form dedicated to each damage type, this class interacts minimally with the data in the form and will be created as part of the overall attack creation, so it is not currently linked to an Ember component.