### PR TITLE
Add Bootstrap formatting to attack form and fix flaky test

### DIFF
--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -1,74 +1,91 @@
-{{!-- <div class="container"> --}}
-  {{!-- <div class="row">
-    <div class="col-sm"> --}}
+<div class="container">
+  <div class="row align-items-top">
+    <div class="col-sm">
       <h2>Current Attack</h2>
-      {{!-- <div class="row row-cols-sm-auto align-items-top">
-        <div class="col"> --}}
+      <div class="row row-cols-sm-auto align-items-top">
+        <div class="col">
           <label for="numberOfAttacks">Number of Attacks</label>
-          <Input data-test-input-numberOfAttacks name="numberOfAttacks" @type="number" @value={{this.numberOfAttacks}} />
-          {{!--
-        </div> --}}
+          <Input data-test-input-numberOfAttacks class="form-control" name="numberOfAttacks" @type="number"
+            @value={{this.numberOfAttacks}} />
+        </div>
 
-        {{!-- <div class="col"> --}}
+        <div class="col">
           <label for="targetAC">Target AC</label>
-          <Input data-test-input-targetAC name="targetAC" @type="number" @value={{this.targetAC}} />
-          {{!--
-        </div> --}}
+          <Input data-test-input-targetAC class="form-control" name="targetAC" @type="number"
+            @value={{this.targetAC}} />
+        </div>
+      </div>
 
-        {{!-- TODO: This does not de-set the variable when switching between the radio buttons --}}
-        <Input data-test-advantage @type="radio" name="advState" id="adv" @value={{this.advantage}} />
+      {{!-- TODO: This does not de-set the variable when switching between the radio buttons --}}
+      <div class="form-check">
+        <Input data-test-advantage class="form-check-input" @type="radio" name="advState" id="adv"
+          @value={{this.advantage}} />
         <label class="form-check-label" for="adv">
           Advantage
         </label>
-        <Input data-test-straight @type="radio" name="advState" id="straight" @value={{this.straightRoll}} />
+      </div>
+      <div class="form-check">
+        <Input data-test-straight class="form-check-input" @type="radio" name="advState" id="straight"
+          @value={{this.straightRoll}} />
         <label class="form-check-label" for="straight">
           Straight roll
         </label>
-        <Input data-test-disadvantage @type="radio" name="advState" id="disadv" @value={{this.disadvantage}} />
+      </div>
+      <div class="form-check">
+        <Input data-test-disadvantage class="form-check-input" @type="radio" name="advState" id="disadv"
+          @value={{this.disadvantage}} />
         <label class="form-check-label" for="disadv">
           Disadvantage
         </label>
+      </div>
 
-        <h3 >Attack Details</h3>
-        {{!-- <div class="row row-cols-sm-auto align-items-top">
-          <div class="col"> --}}
-            <label for="toHit">To Hit Modifier</label>
-            <Input data-test-input-toHit @type="text" name="toHit" @value={{this.toHit}} />
-            {{!--
-          </div>
-        </div> --}}
-
-        {{!-- <div class="row row-cols-sm-auto align-items-top">
-          <div class="col"> --}}
-            <label for="damage">Attack Damage</label>
-            <Input data-test-input-damage @type="text" name="damage" aria-describedby="dmgDescription" @value={{this.damage}} />
-            <small id="dmgDescription" class="form-text text-muted">
-              A string of the form 'XdY+Z' or 'XdY-Z' (ex: 3d8+4).
-            </small>
-
-            {{!-- TODO: Damage type dropdown --}}
-
-            <Input data-test-resistant @type="checkbox" name="resistant" @checked={{this.resistant}} />
-            <label class="form-check-label" for="resistant}">
-              Target Resistant
-            </label>
-            <Input data-test-vulnerable @type="checkbox" name="vulnerable" @checked={{this.vulnerable}} />
-            <label class="form-check-label" for="vulnerable">
-              Target Vulnerable
-            </label>
-
-            <button data-test-button-getDamage type="button" id="attackBtn" {{on "click" this.getDamageMessage}}>Attack!</button>
-            {{!--
-          </div>
+      <h3 class="mt-3">Attack Details</h3>
+      <div class="row row-cols-sm-auto align-items-top">
+        <div class="col">
+          <label for="toHit">To Hit Modifier</label>
+          <Input data-test-input-toHit class="form-control" @type="text" name="toHit" @value={{this.toHit}} />
         </div>
       </div>
-    </div> --}}
 
-    {{!-- <div class="col-lg"> --}}
-      <button data-test-button-getDetails type="button" id="detailsBtn" {{on "click" this.getAttackDetailsMessage}}>Display Attack Details</button>
+      <div class="row row-cols-sm-auto align-items-top">
+        <div class="col">
+          <label for="damage">Attack Damage</label>
+          <Input data-test-input-damage class="form-control" @type="text" name="damage"
+            aria-describedby="dmgDescription" @value={{this.damage}} />
+          <small id="dmgDescription" class="form-text text-muted">
+            A string of the form 'XdY+Z' or 'XdY-Z' (ex: 3d8+4).
+          </small>
+        </div>
+        {{!-- TODO: Damage type dropdown --}}
+      </div>
 
+      <div class="row row-cols-sm-auto align-items-top">
+        <div class="col">
+          <Input data-test-resistant class="form-check-input" @type="checkbox" name="resistant"
+            @checked={{this.resistant}} />
+          <label class="form-check-label" for="resistant}">
+            Target Resistant
+          </label>
+          <Input data-test-vulnerable class="form-check-input" @type="checkbox" name="vulnerable"
+            @checked={{this.vulnerable}} />
+          <label class="form-check-label" for="vulnerable">
+            Target Vulnerable
+          </label>
+        </div>
+      </div>
+
+      <div class="row row-cols-sm-auto align-items-top">
+        <button data-test-button-getDamage class="btn btn-primary m-3" type="button" id="attackBtn" {{on "click"
+          this.getDamageMessage}}>Attack!</button>
+
+        <button data-test-button-getDetails class="btn btn-info m-3" type="button" id="detailsBtn" {{on "click"
+          this.getAttackDetailsMessage}}>Display
+          Attack Details</button>
+      </div>
+    </div>
+
+    <div class="col-lg">
       <Textarea data-test-message id="message" @value={{this.message}} rows="15" cols="80" />
-      {{!--
     </div>
   </div>
-</div> --}}
+</div>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,6 @@
 {{page-title "Multiattack5e"}}
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
+  integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
 
 <RepeatedAttackForm />
 

--- a/tests/acceptance/repeated-attack-form-test.js
+++ b/tests/acceptance/repeated-attack-form-test.js
@@ -5,6 +5,36 @@ import { setupApplicationTest } from 'ember-qunit';
 module('Acceptance | repeated attack form', function (hooks) {
   setupApplicationTest(hooks);
 
+  let detailsRegex = /(?:Attack \d+ .* with an attack roll of -?\d+.*$)/gm;
+
+  test('verifying the regex for attack details', async function (assert) {
+    const text =
+      'Target AC: 15\n' +
+      'Number of attacks: 5\n' +
+      'Attack roll: 1d20 + 3 - 1d6\n' +
+      '(rolls a straight roll, with advantage and disadvantage both set)\n' +
+      'Attack damage: 2d6 + 5 of type piercing\n' +
+      '(target resistant)\n' +
+      '*** Total Damage: 4 ***\n' +
+      '\tAttack 1 inflicted 4 damage with an attack roll of 25 (CRIT!)\n' +
+      '\tAttack 2 missed with an attack roll of -4\n' +
+      '\tAttack 3 missed with an attack roll of 13\n' +
+      '\tAttack 4 missed with an attack roll of 0 (NAT 1!)\n' +
+      '\tAttack 5 missed with an attack roll of 6\n';
+
+    assert.deepEqual(
+      text.match(detailsRegex),
+      [
+        'Attack 1 inflicted 4 damage with an attack roll of 25 (CRIT!)',
+        'Attack 2 missed with an attack roll of -4',
+        'Attack 3 missed with an attack roll of 13',
+        'Attack 4 missed with an attack roll of 0 (NAT 1!)',
+        'Attack 5 missed with an attack roll of 6',
+      ],
+      'the regular expression for the test should match expectations'
+    );
+  });
+
   test('visiting /', async function (assert) {
     await visit('/');
 
@@ -74,13 +104,25 @@ module('Acceptance | repeated attack form', function (hooks) {
       'attack details should be displayed'
     );
 
-    let detailsRegex = /(?:\tAttack \d+ .* with an attack roll of \d+.)/g;
-    assert.equal(
+    assert.strictEqual(
       this.element
         .querySelector('[data-test-message]')
         .value.match(detailsRegex).length,
       8,
       'eight sets of attack details should be displayed'
     );
+
+    // assert.equal(
+    //   this.element.querySelector('[data-test-message]').value,
+    //   'test',
+    //   'printing detailed message'
+    // );
+    // assert.equal(
+    //   this.element
+    //     .querySelector('[data-test-message]')
+    //     .value.match(detailsRegex),
+    //   [],
+    //   'printing matches for the attack details'
+    // );
   });
 });


### PR DESCRIPTION
This adds Bootstrap formatting to the attack form. It also fixes the regular expression for parsing attack details to handle nat 1's, crits, and negative attack rolls, and adds a test of the regular expression to avoid further errors.