### PR TITLE
Add component for handling advantage properly

### DIFF
--- a/app/components/advantage-radio.hbs
+++ b/app/components/advantage-radio.hbs
@@ -1,0 +1,21 @@
+<div class="form-check">
+  <Input data-test-advantage class="form-check-input" @type="radio" name="advState" id="adv" {{on "click" (fn
+    @updateState this.AdvantageState.ADVANTAGE) }} />
+  <label class="form-check-label" for="adv">
+    Advantage
+  </label>
+</div>
+<div class="form-check">
+  <Input data-test-straight class="form-check-input" @type="radio" name="advState" id="straight" checked {{on "click" (fn
+    @updateState this.AdvantageState.STRAIGHT) }} />
+  <label class="form-check-label" for="straight">
+    Straight roll
+  </label>
+</div>
+<div class="form-check">
+  <Input data-test-disadvantage class="form-check-input" @type="radio" name="advState" id="disadv" {{on "click" (fn
+    @updateState this.AdvantageState.DISADVANTAGE) }} />
+  <label class="form-check-label" for="disadv">
+    Disadvantage
+  </label>
+</div>

--- a/app/components/advantage-radio.ts
+++ b/app/components/advantage-radio.ts
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import AdvantageState from './advantage-state';
+
+export default class AdvantageRadioComponent extends Component {
+  AdvantageState = AdvantageState;
+}

--- a/app/components/advantage-state.ts
+++ b/app/components/advantage-state.ts
@@ -1,0 +1,11 @@
+export default class AdvantageState {
+  static ADVANTAGE = new AdvantageState('advantage');
+  static STRAIGHT = new AdvantageState('straight');
+  static DISADVANTAGE = new AdvantageState('disadvantage');
+
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -16,28 +16,7 @@
         </div>
       </div>
 
-      {{!-- TODO: This does not de-set the variable when switching between the radio buttons --}}
-      <div class="form-check">
-        <Input data-test-advantage class="form-check-input" @type="radio" name="advState" id="adv"
-          @value={{this.advantage}} />
-        <label class="form-check-label" for="adv">
-          Advantage
-        </label>
-      </div>
-      <div class="form-check">
-        <Input data-test-straight class="form-check-input" @type="radio" name="advState" id="straight"
-          @value={{this.straightRoll}} />
-        <label class="form-check-label" for="straight">
-          Straight roll
-        </label>
-      </div>
-      <div class="form-check">
-        <Input data-test-disadvantage class="form-check-input" @type="radio" name="advState" id="disadv"
-          @value={{this.disadvantage}} />
-        <label class="form-check-label" for="disadv">
-          Disadvantage
-        </label>
-      </div>
+      <AdvantageRadio @updateState={{this.setAdvantageState}}/>
 
       <h3 class="mt-3">Attack Details</h3>
       <div class="row row-cols-sm-auto align-items-top">

--- a/tests/acceptance/repeated-attack-form-test.js
+++ b/tests/acceptance/repeated-attack-form-test.js
@@ -97,7 +97,7 @@ module('Acceptance | repeated attack form', function (hooks) {
           'Target AC: 15\n' +
             'Number of attacks: 8\n' +
             'Attack roll: 1d20 + 3 - 1d6\n' +
-            '(rolls a straight roll, with advantage and disadvantage both set)\n' +
+            '(rolls with disadvantage)\n' +
             'Attack damage: 2d6 + 5 of type piercing\n' +
             '(target resistant)'
         ),

--- a/tests/integration/components/advantage-radio-test.js
+++ b/tests/integration/components/advantage-radio-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import AdvantageState from 'multiattack-5e/components/advantage-state';
+
+module('Integration | Component | advantage-radio', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it initially renders as expected', async function (assert) {
+    this.set('updateState', (actual) => {
+      assert.true(
+        false,
+        `updateState should not be called in initial render but was called with ${actual}`
+      );
+    });
+
+    assert.expect(0);
+    await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
+  });
+
+  test('it sets advantage as expected', async function (assert) {
+    this.set('updateState', (actual) => {
+      assert.deepEqual(
+        actual,
+        AdvantageState.ADVANTAGE,
+        'advantage should have been passed to the updateState function'
+      );
+    });
+
+    await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
+
+    assert.expect(1);
+    await click('[data-test-advantage]');
+  });
+
+  test('it sets disadvantage as expected', async function (assert) {
+    this.set('updateState', (actual) => {
+      assert.deepEqual(
+        actual,
+        AdvantageState.DISADVANTAGE,
+        'disadvantage should have been passed to the updateState function'
+      );
+    });
+
+    await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
+
+    assert.expect(1);
+    await click('[data-test-disadvantage]');
+  });
+
+  test('it sets a straight roll as expected', async function (assert) {
+    this.set('updateState', (actual) => {
+      assert.deepEqual(
+        actual,
+        AdvantageState.STRAIGHT,
+        'straight roll should have been set'
+      );
+    });
+
+    await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
+
+    assert.expect(1);
+    await click('[data-test-straight]');
+  });
+});


### PR DESCRIPTION
This introduces a new component for correctly handling advantage; unlike the initial implementation, this allows exactly one state (advantage, disadvantage, or straight roll). The UI no longer supports checking both advantage and disadvantage (although it never appeared to do so, making the new behavior significantly less confusing). If an attack has both advantage and disadvantage, it can be modeled directly as a straight roll.