### PR TITLE
Make the damage parser methods static

### DIFF
--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -28,7 +28,7 @@ export default class Attack {
    * with details for each
    */
   constructor(toHit: string, damageTypes: Damage[]) {
-    this.toHitModifier = new DiceStringParser().parse(toHit);
+    this.toHitModifier = DiceStringParser.parse(toHit);
     this.damageTypes = damageTypes;
   }
 

--- a/app/utils/damage.ts
+++ b/app/utils/damage.ts
@@ -16,7 +16,7 @@ export default class Damage {
     targetResistant = false,
     targetVulnerable = false
   ) {
-    this.damage = new DiceStringParser().parse(damageString);
+    this.damage = DiceStringParser.parse(damageString);
     this.damageString = damageString;
     this.type = type;
     this.targetResistant = targetResistant;

--- a/app/utils/dice-string-parser.ts
+++ b/app/utils/dice-string-parser.ts
@@ -8,13 +8,13 @@ export default class DiceStringParser {
   // except for the first term, where the sign is optional. Note that this regex
   // cannot be marked with "g" or it will preserve state between different
   // strings and incorrectly mark some as not matching.
-  diceStringRegex =
+  static diceStringRegex =
     /^(?: *[+-]? *(?:(?:\d+d\d+)|\d+))(?: *[+-] *(?:(?:\d+d\d+)|\d+))*$/i;
 
   // Matches a dice group or number with an optional sign. This uses "g" to
   // enable parsing many terms out of the same expression; the code makes sure
   // to consume all possible matches each time it is used.
-  termRegex =
+  static termRegex =
     /(?: *(?<sign>[+-]?) *(?:(?:(?<numDice>\d+)d(?<numSides>\d+))|(?<number>\d+)))/gi;
 
   /**
@@ -26,7 +26,7 @@ export default class DiceStringParser {
    * @returns the list of described dice groups and all of the numbers added
    * together into a single modifier
    */
-  parse(diceString: string): DiceGroupsAndModifier {
+  static parse(diceString: string): DiceGroupsAndModifier {
     // Check that the string matches the overall expected pattern, with no
     // additional text or missing signs
     if (!this.diceStringRegex.test(diceString)) {

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { click, fillIn, visit, currentURL, select } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { ElementContext } from '../types/element-context';
-// import assert from 'qunit-dom';
 
 module('Acceptance | repeated attack form', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/unit/utils/dice-string-parser-test.ts
+++ b/tests/unit/utils/dice-string-parser-test.ts
@@ -23,7 +23,7 @@ module('Unit | Utils | dice-string-parser', function (hooks) {
 
     for (const invalid of invalidStrings) {
       assert.throws(
-        () => new DiceStringParser().parse(invalid),
+        () => DiceStringParser.parse(invalid),
         new Error(
           `Unable to parse dice groups or constants from input string "${invalid}"`
         ),
@@ -58,11 +58,10 @@ module('Unit | Utils | dice-string-parser', function (hooks) {
 
     assert.expect(valid.size);
 
-    const parser = new DiceStringParser();
     for (const [dmgStr, expected] of valid) {
       try {
         assert.deepEqual(
-          parser.parse(dmgStr),
+          DiceStringParser.parse(dmgStr),
           expected,
           `${dmgStr} should parse to expected value`
         );


### PR DESCRIPTION
Since the damage parser uses no class-specific state, its methods can be static rather than creating multiple objects.