### PR TITLE
Add validation on form inputs

### DIFF
--- a/app/components/damage-type.hbs
+++ b/app/components/damage-type.hbs
@@ -2,7 +2,8 @@
   <div class="col">
     <label for="damage">Attack Damage</label>
     <Input data-test-input-damage class="form-control" @type="text" name="damage" aria-describedby="dmgDescription"
-      @value={{@initialDamage}} {{on "input" (fn @setDamage)}} />
+      @value={{@initialDamage}} {{on "input" (fn @setDamage)}} pattern={{this.diceGroupsRegex}}
+      title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '+1d4 - 1d6 + 2'" />
     <small id="dmgDescription" class="form-text text-muted">
       A string of the form 'XdY+Z' or 'XdY-Z' (ex: 3d8+4).
     </small>
@@ -21,7 +22,8 @@
 
 <div class="row row-cols-sm-auto align-items-top">
   <div class="col">
-    <Input data-test-input-resistant class="form-check-input" @type="checkbox" name="resistant" @checked={{@initialResistant}} {{on "input" (fn @setResistant)}} />
+    <Input data-test-input-resistant class="form-check-input" @type="checkbox" name="resistant"
+      @checked={{@initialResistant}} {{on "input" (fn @setResistant)}} />
     <label class="form-check-label" for="resistant">
       Target Resistant
     </label>

--- a/app/components/damage-type.ts
+++ b/app/components/damage-type.ts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import DiceStringParser from 'multiattack-5e/utils/dice-string-parser';
 
 export default class DamageTypeComponent extends Component {
   damageTypes = [
@@ -17,4 +18,6 @@ export default class DamageTypeComponent extends Component {
     'Thunder',
     'Other',
   ];
+
+  diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
 }

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -1,44 +1,48 @@
 <div class="container">
   <div class="row align-items-top">
     <div class="col-sm">
-      <h2>Current Attack</h2>
-      <div class="row row-cols-sm-auto align-items-top">
-        <div class="col">
-          <label for="numberOfAttacks">Number of Attacks</label>
-          <Input data-test-input-numberOfAttacks class="form-control" name="numberOfAttacks" @type="number"
-            @value={{this.numberOfAttacks}} />
+      <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
+        <h2>Current Attack</h2>
+        <div class="row row-cols-sm-auto align-items-top">
+          <div class="col">
+            <label for="numberOfAttacks">Number of Attacks</label>
+            <Input data-test-input-numberOfAttacks class="form-control" name="numberOfAttacks" @type="number"
+              @value={{this.numberOfAttacks}} min="0" title="Number of attacks cannot be negative" />
+          </div>
+
+          <div class="col">
+            <label for="targetAC">Target AC</label>
+            <Input data-test-input-targetAC class="form-control" name="targetAC" @type="number"
+              @value={{this.targetAC}} />
+          </div>
         </div>
 
-        <div class="col">
-          <label for="targetAC">Target AC</label>
-          <Input data-test-input-targetAC class="form-control" name="targetAC" @type="number"
-            @value={{this.targetAC}} />
+        <AdvantageRadio @updateState={{this.setAdvantageState}} />
+
+        <h3 class="mt-3">Attack Details</h3>
+        <div class="row row-cols-sm-auto align-items-top">
+          <div class="col">
+            <label for="toHit">To Hit Modifier</label>
+            <Input data-test-input-toHit class="form-control" @type="text" name="toHit" @value={{this.toHit}}
+              pattern={{this.diceGroupsRegex}}
+              title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '+1d4 - 1d6 + 2'" />
+          </div>
         </div>
-      </div>
 
-      <AdvantageRadio @updateState={{this.setAdvantageState}} />
+        <DamageType @setDamage={{this.setDamage}} @setDamageType={{this.setDamageType}}
+          @setResistant={{this.setResistant}} @setVulnerable={{this.setVulnerable}} @initialDamage={{this.damage}}
+          @initialDamageType={{this.damageType}} @initialResistant={{this.resistant}}
+          @initialVulnerable={{this.vulnerable}} />
 
-      <h3 class="mt-3">Attack Details</h3>
-      <div class="row row-cols-sm-auto align-items-top">
-        <div class="col">
-          <label for="toHit">To Hit Modifier</label>
-          <Input data-test-input-toHit class="form-control" @type="text" name="toHit" @value={{this.toHit}} />
+        <div class="row row-cols-sm-auto align-items-top">
+          <button data-test-button-getDamage class="btn btn-primary m-3" type="submit" id="attackBtn" {{on "click"
+            this.getDamageMessage}}>Attack!</button>
+
+          <button data-test-button-getDetails class="btn btn-info m-3" type="submit" id="detailsBtn" {{on "click"
+            this.getAttackDetailsMessage}}>Display
+            Attack Details</button>
         </div>
-      </div>
-
-      <DamageType @setDamage={{this.setDamage}} @setDamageType={{this.setDamageType}}
-        @setResistant={{this.setResistant}} @setVulnerable={{this.setVulnerable}} @initialDamage={{this.damage}}
-        @initialDamageType={{this.damageType}} @initialResistant={{this.resistant}}
-        @initialVulnerable={{this.vulnerable}} />
-
-      <div class="row row-cols-sm-auto align-items-top">
-        <button data-test-button-getDamage class="btn btn-primary m-3" type="button" id="attackBtn" {{on "click"
-          this.getDamageMessage}}>Attack!</button>
-
-        <button data-test-button-getDetails class="btn btn-info m-3" type="button" id="detailsBtn" {{on "click"
-          this.getAttackDetailsMessage}}>Display
-          Attack Details</button>
-      </div>
+      </form>
     </div>
 
     <div class="col-lg">

--- a/app/components/repeated-attack-form.ts
+++ b/app/components/repeated-attack-form.ts
@@ -5,21 +5,35 @@ import Attack from 'multiattack-5e/utils/attack';
 import Damage from 'multiattack-5e/utils/damage';
 import AdvantageState from './advantage-state';
 import { assert } from '@ember/debug';
+import DiceStringParser from 'multiattack-5e/utils/dice-string-parser';
 
 export default class RepeatedAttackFormComponent extends Component {
   @tracked numberOfAttacks = 0;
   @tracked targetAC = 0;
 
   @tracked toHit = '5 + 1d4';
-  damage = '2d6 + 3';
-  damageType = 'Piercing';
+  @tracked damage = '2d6 + 3';
+  @tracked damageType = 'Piercing';
 
-  resistant = false;
-  vulnerable = false;
+  @tracked resistant = false;
+  @tracked vulnerable = false;
 
   @tracked message = this.getAttackDetails();
 
+  diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
+
   advantageState = AdvantageState.STRAIGHT;
+
+  /**
+   * This function is used to stop the repeated-attack-form handlebars from
+   * refreshing the page whenever the form is submitted. Without this, the tests
+   * which use form submission enter an infinite loop.
+   * @returns false
+   */
+  @action
+  suppressPageRefresh() {
+    return false;
+  }
 
   @action
   setAdvantageState(newState: AdvantageState) {
@@ -46,7 +60,7 @@ export default class RepeatedAttackFormComponent extends Component {
       newDamage.target instanceof HTMLInputElement
     );
 
-    this.damage = newDamage.target.value || '2d6 + 3';
+    this.damage = newDamage.target.value || '0';
   }
 
   @action

--- a/app/utils/dice-string-parser.ts
+++ b/app/utils/dice-string-parser.ts
@@ -8,14 +8,31 @@ export default class DiceStringParser {
   // except for the first term, where the sign is optional. Note that this regex
   // cannot be marked with "g" or it will preserve state between different
   // strings and incorrectly mark some as not matching.
-  static diceStringRegex =
-    /^(?: *[+-]? *(?:(?:\d+d\d+)|\d+))(?: *[+-] *(?:(?:\d+d\d+)|\d+))*$/i;
+  static diceStringRegexAsString =
+    '(?: *[\\+\\-]? *(?:(?:\\d+d\\d+)|\\d+))(?: *[\\+\\-] *(?:(?:\\d+d\\d+)|\\d+))*';
+  static diceStringRegex = new RegExp(
+    '^' + this.diceStringRegexAsString + '$',
+    'i'
+  );
+  // /^(?: *[+-]? *(?:(?:\d+d\d+)|\d+))(?: *[+-] *(?:(?:\d+d\d+)|\d+))*$/i;
 
   // Matches a dice group or number with an optional sign. This uses "g" to
   // enable parsing many terms out of the same expression; the code makes sure
   // to consume all possible matches each time it is used.
   static termRegex =
     /(?: *(?<sign>[+-]?) *(?:(?:(?<numDice>\d+)d(?<numSides>\d+))|(?<number>\d+)))/gi;
+
+  /**
+   * Check whether the input string can be parsed as a series of dice groups
+   * and/or numbers added to or subtracted from each other, such as is used to
+   * describe damage in systems like D&D 5e.
+   * @param potentialDiceString a string which might be a series of dice groups
+   * and/or numbers added to or subtracted from each other
+   * @returns whether this string matches the expected format
+   */
+  static validateDiceString(potentialDiceString: string): boolean {
+    return this.diceStringRegex.test(potentialDiceString);
+  }
 
   /**
    * Parses a combination of dice groups and numbers, such as the string used to
@@ -29,7 +46,7 @@ export default class DiceStringParser {
   static parse(diceString: string): DiceGroupsAndModifier {
     // Check that the string matches the overall expected pattern, with no
     // additional text or missing signs
-    if (!this.diceStringRegex.test(diceString)) {
+    if (!this.validateDiceString(diceString)) {
       throw new Error(
         `Unable to parse dice groups or constants from input string "${diceString}"`
       );

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -131,4 +131,41 @@ module('Acceptance | repeated attack form', function (hooks) {
     //   'printing matches for the attack details'
     // );
   });
+
+  test('it invalidates malformatted fields', async function (this: ElementContext, assert) {
+    await visit('/');
+
+    // numberOfAttacks
+    await fillIn('[data-test-input-numberOfAttacks]', '8');
+    assert
+      .dom('[data-test-input-numberOfAttacks]')
+      .isValid('initial number of attacks should be valid');
+
+    await fillIn('[data-test-input-numberOfAttacks]', '-2');
+    assert
+      .dom('[data-test-input-numberOfAttacks]')
+      .isNotValid('invalid input number of attacks should be flagged');
+
+    // toHit
+    await fillIn('[data-test-input-toHit]', '3 - 1d6');
+    assert
+      .dom('[data-test-input-toHit]')
+      .isValid('initial toHit should be valid');
+
+    await fillIn('[data-test-input-toHit]', 'invalid');
+    assert
+      .dom('[data-test-input-toHit]')
+      .isNotValid('invalid input toHit should be flagged');
+
+    // damage
+    await fillIn('[data-test-input-damage]', '2d6 + 3');
+    assert
+      .dom('[data-test-input-damage]')
+      .isValid('initial damage should be valid');
+
+    await fillIn('[data-test-input-damage]', 'invalid');
+    assert
+      .dom('[data-test-input-damage]')
+      .isNotValid('invalid input damage should be flagged');
+  });
 });


### PR DESCRIPTION
This validates the input dice strings to ensure that they match the regular expression for a sum of dice or numbers. This requires making the frontend an HTML form, with page refresh suppressed so that the tests do not loop infinitely.