### PR TITLE
Reduce repeated code in advantage radio button

### DIFF
--- a/app/components/advantage-radio.hbs
+++ b/app/components/advantage-radio.hbs
@@ -1,21 +1,10 @@
+{{#each this.states as |state|}}
 <div class="form-check">
-  <Input data-test-advantage class="form-check-input" @type="radio" name="advState" id="adv" {{on "click" (fn
-    @updateState this.AdvantageState.ADVANTAGE) }} />
-  <label class="form-check-label" for="adv">
-    Advantage
+  {{!-- Unfortunately, the Input element of type "radio" does not currently support the @checked/checked attribute. This means we cannot configure one of the buttons to be checked initially.  --}}
+  <Input data-test-value={{state.name}} class="form-check-input" @type="radio" name="advantage-radio" id={{state.name}}
+    {{on "click" (fn @updateState state) }} />
+  <label class="form-check-label" for={{state.name}}>
+    {{state.name}}
   </label>
 </div>
-<div class="form-check">
-  <Input data-test-straight class="form-check-input" @type="radio" name="advState" id="straight" checked {{on "click" (fn
-    @updateState this.AdvantageState.STRAIGHT) }} />
-  <label class="form-check-label" for="straight">
-    Straight roll
-  </label>
-</div>
-<div class="form-check">
-  <Input data-test-disadvantage class="form-check-input" @type="radio" name="advState" id="disadv" {{on "click" (fn
-    @updateState this.AdvantageState.DISADVANTAGE) }} />
-  <label class="form-check-label" for="disadv">
-    Disadvantage
-  </label>
-</div>
+{{/each}}

--- a/app/components/advantage-radio.ts
+++ b/app/components/advantage-radio.ts
@@ -3,4 +3,10 @@ import AdvantageState from './advantage-state';
 
 export default class AdvantageRadioComponent extends Component {
   AdvantageState = AdvantageState;
+
+  states = [
+    AdvantageState.ADVANTAGE,
+    AdvantageState.STRAIGHT,
+    AdvantageState.DISADVANTAGE,
+  ];
 }

--- a/app/components/repeated-attack-form.ts
+++ b/app/components/repeated-attack-form.ts
@@ -20,9 +20,9 @@ export default class RepeatedAttackFormComponent extends Component {
 
   @tracked message = this.getAttackDetails();
 
-  diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
+  @tracked advantageState = AdvantageState.STRAIGHT;
 
-  advantageState = AdvantageState.STRAIGHT;
+  diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
 
   /**
    * This function is used to stop the repeated-attack-form handlebars from

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -85,8 +85,8 @@ module('Acceptance | repeated attack form', function (hooks) {
     await fillIn('[data-test-input-toHit]', '3 - 1d6');
     await fillIn('[data-test-input-damage]', '2d6 + 5');
     await select('[data-test-damage-dropdown]', '[data-test-damage-Acid]');
-    await click('[data-test-advantage]');
-    await click('[data-test-disadvantage]');
+    await click('[data-test-value="advantage"]');
+    await click('[data-test-value="disadvantage"]');
     await click('[data-test-input-resistant]');
 
     // Calculate the attack

--- a/tests/integration/components/advantage-radio-test.ts
+++ b/tests/integration/components/advantage-radio-test.ts
@@ -31,7 +31,7 @@ module('Integration | Component | advantage-radio', function (hooks) {
     await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
 
     assert.expect(1);
-    await click('[data-test-advantage]');
+    await click('[data-test-value="advantage"]');
   });
 
   test('it sets disadvantage as expected', async function (assert) {
@@ -46,7 +46,7 @@ module('Integration | Component | advantage-radio', function (hooks) {
     await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
 
     assert.expect(1);
-    await click('[data-test-disadvantage]');
+    await click('[data-test-value="disadvantage"]');
   });
 
   test('it sets a straight roll as expected', async function (assert) {
@@ -61,6 +61,6 @@ module('Integration | Component | advantage-radio', function (hooks) {
     await render(hbs`<AdvantageRadio @updateState={{this.updateState}} />`);
 
     assert.expect(1);
-    await click('[data-test-straight]');
+    await click('[data-test-value="straight"]');
   });
 });


### PR DESCRIPTION
This introduces a loop over possible advantage states to reduce repeated code in the radio button component. Unfortunately, Ember's radio button input does not support a "checked" attribute and the ember-radio-button and ember-radio-buttons plugins are several years out of date. This means that it does not appear possible to have the buttons initialized with one of the values already selected (if we used checkboxes, this would be possible, but this would lose the constraint that only one button can be selected).