### PR TITLE
Add details for damage to each attack

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -27,9 +27,9 @@
   <strong>*** Total Damage: {{@totalDmg}} ***</strong>
 </h4>
 <ol data-test-attack-detail-list>
-  {{#each @attackDetailsList as |attackDetails|}}
+  {{#each @attackDetailsList as |attackDetails index|}}
   <li>
-    Attack {{@index}}
+    Attack
     {{#if attackDetails.hit }}
     inflicted {{attackDetails.damage}} damage
     {{/if}}
@@ -39,6 +39,15 @@
     with an attack roll of {{attackDetails.roll}}
     {{#if attackDetails.crit}} (CRIT!){{/if}}
     {{#if attackDetails.nat1}} (NAT 1!){{/if}}
+    <ul data-test-damage-detail-list={{index}}>
+      {{#each attackDetails.damageDetails as |damage|}}
+      <li>
+        {{damage.label}}: {{damage.roll}} damage
+        {{#if damage.resisted}} (resisted){{/if}}
+        {{#if damage.vulnerable}} (vulnerable){{/if}}
+      </li>
+      {{/each}}
+    </ul>
   </li>
   {{/each}}
 </ol>

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -9,7 +9,14 @@ export interface AttackDetails {
   crit: boolean;
   nat1: boolean;
   damage: number;
-  damageDetails: Map<string, number>;
+  damageDetails: DamageDetails[];
+}
+
+export interface DamageDetails {
+  label: string;
+  roll: number;
+  resisted: boolean;
+  vulnerable: boolean;
 }
 
 export default class Attack {
@@ -55,7 +62,7 @@ export default class Attack {
     const nat1 = attackD20 == 1;
 
     let totalDmg = 0;
-    const damageDetails = new Map();
+    const damageDetails: DamageDetails[] = [];
 
     // Attacks always miss on a nat1, always hit on a crit, and otherwise hit if
     // the roll equals or exceeds the target AC.
@@ -64,10 +71,12 @@ export default class Attack {
       for (const damage of this.damageTypes) {
         const rolledDmg = damage.roll(crit);
         totalDmg += rolledDmg;
-        // This will overwrite a damage record if the attack has multiple damage
-        // components of the same type with the same damage string, but this is
-        // unlikely
-        damageDetails.set(`${damage.type} (${damage.damageString})`, rolledDmg);
+        damageDetails.push({
+          label: `${damage.type} (${damage.damageString})`,
+          roll: rolledDmg,
+          resisted: damage.targetResistant,
+          vulnerable: damage.targetVulnerable,
+        });
       }
     }
 

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -48,7 +48,21 @@ module('Integration | Component | detail-display', function (hooks) {
         hit: true,
         crit: true,
         nat1: false,
-        damage: 4,
+        damage: 22,
+        damageDetails: [
+          {
+            label: 'Piercing (2d6 + 5 + 1d4)',
+            roll: 8,
+            resisted: true,
+            vulnerable: false,
+          },
+          {
+            label: 'Radiant (2d8)',
+            roll: 14,
+            resisted: false,
+            vulnerable: true,
+          },
+        ],
       },
       {
         roll: -4,
@@ -82,7 +96,7 @@ module('Integration | Component | detail-display', function (hooks) {
     this.set('damageList', [new Damage('2d6 + 5', 'Acid', true, true)]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks=8 @targetAC=15 @toHit="3 - 1d6"  @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered=false @attackTriggered=true @totalDmg=4 @attackDetailsList={{this.attackDetails}} />`
+      hbs`<DetailDisplay @numberOfAttacks=8 @targetAC=15 @toHit="3 - 1d6"  @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered=false @attackTriggered=true @totalDmg=22 @attackDetailsList={{this.attackDetails}} />`
     );
 
     assert
@@ -101,7 +115,7 @@ module('Integration | Component | detail-display', function (hooks) {
 
     assert
       .dom('[data-test-total-damage-header]')
-      .hasText('*** Total Damage: 4 ***');
+      .hasText('*** Total Damage: 22 ***');
 
     assert
       .dom('[data-test-attack-detail-list]')
@@ -120,7 +134,7 @@ module('Integration | Component | detail-display', function (hooks) {
 
       assert.equal(
         detailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack inflicted 4 damage with an attack roll of 25 (CRIT!)',
+        'Attack inflicted 22 damage with an attack roll of 25 (CRIT!) Piercing (2d6 + 5 + 1d4): 8 damage (resisted) Radiant (2d8): 14 damage (vulnerable)',
         'critical hit should be correctly displayed'
       );
       assert.equal(
@@ -142,6 +156,32 @@ module('Integration | Component | detail-display', function (hooks) {
         detailsList[4]?.textContent?.trim().replace(/\s+/g, ' '),
         'Attack missed with an attack roll of 6',
         'single-digit attack roll with a miss should be properly displayed'
+      );
+    }
+
+    const damageDetailsList = this.element.querySelector(
+      '[data-test-damage-detail-list="0"]'
+    )?.children;
+    assert.true(
+      damageDetailsList != null,
+      'damage detail list should be present'
+    );
+    if (damageDetailsList) {
+      assert.equal(
+        damageDetailsList.length,
+        2,
+        '2 types of damage should have been displayed'
+      );
+
+      assert.equal(
+        damageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
+        'Piercing (2d6 + 5 + 1d4): 8 damage (resisted)',
+        'piercing damage details should be displayed'
+      );
+      assert.equal(
+        damageDetailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
+        'Radiant (2d8): 14 damage (vulnerable)',
+        'radiant damage details should be displayed'
       );
     }
   });

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
-import Attack from 'multiattack-5e/utils/attack';
+import Attack, { DamageDetails } from 'multiattack-5e/utils/attack';
 import Damage from 'multiattack-5e/utils/damage';
 
 module('Unit | Utils | attack', function (hooks) {
@@ -196,8 +196,8 @@ module('Unit | Utils | attack', function (hooks) {
 
   test('it adds damage dice as expected', async function (assert) {
     const attack = new Attack('5', [
-      new Damage('2d6 + 5 + 1d4', 'piercing'),
-      new Damage('2d8', 'radiant'),
+      new Damage('2d6 + 5 + 1d4', 'Piercing'),
+      new Damage('2d8', 'Radiant'),
     ]);
 
     // Fake the results of the d20 attack roll
@@ -236,9 +236,20 @@ module('Unit | Utils | attack', function (hooks) {
       20,
       '20 damage should have been inflicted'
     );
-    const expectedDmg: Map<string, number> = new Map();
-    expectedDmg.set('piercing (2d6 + 5 + 1d4)', 13);
-    expectedDmg.set('radiant (2d8)', 7);
+    const expectedDmg: DamageDetails[] = [
+      {
+        label: 'Piercing (2d6 + 5 + 1d4)',
+        roll: 13,
+        resisted: false,
+        vulnerable: false,
+      },
+      {
+        label: 'Radiant (2d8)',
+        roll: 7,
+        resisted: false,
+        vulnerable: false,
+      },
+    ];
     assert.deepEqual(
       attackData.damageDetails,
       expectedDmg,
@@ -248,8 +259,8 @@ module('Unit | Utils | attack', function (hooks) {
 
   test('it handles a critical hit as expected', async function (assert) {
     const attack = new Attack('-5', [
-      new Damage('2d6 + 5 + 1d4', 'piercing'),
-      new Damage('2d8', 'radiant'),
+      new Damage('2d6 + 5 + 1d4', 'Piercing'),
+      new Damage('2d8', 'Radiant'),
     ]);
 
     // Fake the results of the d20 attack roll
@@ -291,9 +302,20 @@ module('Unit | Utils | attack', function (hooks) {
       39,
       '39 damage should have been inflicted (25 + 14)'
     );
-    const expectedDmg: Map<string, number> = new Map();
-    expectedDmg.set('piercing (2d6 + 5 + 1d4)', 25);
-    expectedDmg.set('radiant (2d8)', 14);
+    const expectedDmg: DamageDetails[] = [
+      {
+        label: 'Piercing (2d6 + 5 + 1d4)',
+        roll: 25,
+        resisted: false,
+        vulnerable: false,
+      },
+      {
+        label: 'Radiant (2d8)',
+        roll: 14,
+        resisted: false,
+        vulnerable: false,
+      },
+    ];
     assert.deepEqual(
       attackData.damageDetails,
       expectedDmg,


### PR DESCRIPTION
This displays the damage details for each attack as a dropdown below the primary list. It also updates the backend to send additional information about each damage type in the attack.