### PR TITLE
Fix handling of initial sign on toHit modifier

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -4,7 +4,7 @@
 <ul data-test-plan-detail-list>
   <li>Target AC: {{@targetAC}}</li>
   <li>Number of attacks: {{@numberOfAttacks}}</li>
-  <li>Attack roll: 1d20 + {{@toHit}}
+  <li>Attack roll: {{this.getAttackString @toHit}}
     {{#if (eq @advantageState.name "advantage") }}
     (rolls with advantage)
     {{/if}}

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -3,4 +3,21 @@ import AdvantageState from './advantage-state';
 
 export default class DetailDisplayComponent extends Component {
   AdvantageState = AdvantageState;
+
+  /**
+   * Use the given toHit modifier to represent a 1d20 roll with this modifier.
+   * If the input modifier has no sign at the start of the string, it will be
+   * assumed to be positive.
+   * @param toHit a string representing a group of dice and/or numbers added
+   * together
+   * @returns a string representing the toHit string added to 1d20
+   */
+  getAttackString = (toHit: string) => {
+    toHit = toHit.trim();
+    if (toHit.startsWith('+') || toHit.startsWith('-')) {
+      return `1d20 ${toHit}`;
+    } else {
+      return `1d20 + ${toHit}`;
+    }
+  };
 }


### PR DESCRIPTION
The initial implementation of the details pane hardcoded "1d20 + toHit", which caused there to be an extra sign in the term if there was an initial "+" or "-" in the toHit string. This adds logic to avoid introducing the extra "+". 