### PR TITLE
Fix errors for handlebars linter

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,8 +1,6 @@
 {{page-title "Multiattack5e"}}
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
   integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
-  integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 
 <div class="container">
   <Header />

--- a/tests/integration/components/damage-type-test.ts
+++ b/tests/integration/components/damage-type-test.ts
@@ -22,7 +22,7 @@ module('Integration | Component | damage-type', function (hooks) {
     this.set('resistant', true);
     this.set('vulnerable', false);
 
-    await render(hbs`<DamageType @index=0 @setDamage={{this.doNotCall}} @setDamageType={{this.doNotCall}}
+    await render(hbs`<DamageType @index={{0}} @setDamage={{this.doNotCall}} @setDamageType={{this.doNotCall}}
     @setResistant={{this.doNotCall}} @setVulnerable={{this.doNotCall}} @initialDamage={{this.damage}}
     @initialDamageType={{this.damageType}} @initialResistant={{this.resistant}}
     @initialVulnerable={{this.vulnerable}} />`);
@@ -99,7 +99,7 @@ module('Integration | Component | damage-type', function (hooks) {
     this.set('resistant', true);
     this.set('vulnerable', false);
 
-    await render(hbs`<DamageType @index=3 @setDamage={{this.setDamage}} @setDamageType={{this.setDamageType}}
+    await render(hbs`<DamageType @index={{3}} @setDamage={{this.setDamage}} @setDamageType={{this.setDamageType}}
     @setResistant={{this.setResistant}} @setVulnerable={{this.setVulnerable}} @initialDamage={{this.damage}}
     @initialDamageType={{this.damageType}} @initialResistant={{this.resistant}}
     @initialVulnerable={{this.vulnerable}} />`);
@@ -153,7 +153,7 @@ module('Integration | Component | damage-type', function (hooks) {
     this.set('resistant', true);
     this.set('vulnerable', false);
 
-    await render(hbs`<DamageType @index=0 @setDamage={{this.setDamage}} @setDamageType={{this.doNotCall}}
+    await render(hbs`<DamageType @index={{0}} @setDamage={{this.setDamage}} @setDamageType={{this.doNotCall}}
     @setResistant={{this.doNotCall}} @setVulnerable={{this.doNotCall}} @initialDamage={{this.damage}}
     @initialDamageType={{this.damageType}} @initialResistant={{this.resistant}}
     @initialVulnerable={{this.vulnerable}} />`);

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -18,7 +18,7 @@ module('Integration | Component | detail-display', function (hooks) {
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks=8 @targetAC=15 @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered=false />`
+      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{false}} />`
     );
 
     assert
@@ -102,7 +102,7 @@ module('Integration | Component | detail-display', function (hooks) {
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks=8 @targetAC=15 @toHit="3 - 1d6"  @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered=false @attackTriggered=true @totalDmg=22 @attackDetailsList={{this.attackDetails}} />`
+      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{22}} @attackDetailsList={{this.attackDetails}} />`
     );
 
     assert


### PR DESCRIPTION
This fixes invalid Handlebars syntax in test cases and removes the Bootstrap script from application.hbs, which appears to be unused (the linter alerts that it is forbidden, and removing it does not change the page's behavior).