### PR TITLE
Capitalize damage types in attack detail display

### DIFF
--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -72,7 +72,9 @@ export default class Attack {
         const rolledDmg = damage.roll(crit);
         totalDmg += rolledDmg;
         damageDetails.push({
-          label: `${damage.type} (${damage.damageString})`,
+          label: `${Attack.capitalizeWord(damage.type)} (${
+            damage.damageString
+          })`,
           roll: rolledDmg,
           resisted: damage.targetResistant,
           vulnerable: damage.targetVulnerable,
@@ -113,4 +115,15 @@ export default class Attack {
       );
     }
   }
+
+  static capitalizeWord = (word: string) => {
+    if (word.length == 0) {
+      return word;
+    }
+    const firstLetter = word.charAt(0).toUpperCase();
+    if (word.length == 1) {
+      return firstLetter;
+    }
+    return firstLetter + word.slice(1);
+  };
 }

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -18,7 +18,7 @@ module('Integration | Component | detail-display', function (hooks) {
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{false}} />`
+      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="- 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{false}} />`
     );
 
     assert
@@ -26,7 +26,7 @@ module('Integration | Component | detail-display', function (hooks) {
       .hasText(
         'Target AC: 15\n' +
           'Number of attacks: 8\n' +
-          'Attack roll: 1d20 + 3 - 1d6 (rolls with disadvantage)\n' +
+          'Attack roll: 1d20 - 1d6 (rolls with disadvantage)\n' +
           'Attack damage: 2d6 + 5 acid damage (target resistant) (target vulnerable)',
         'the details for the input damage should be displayed'
       );

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -240,13 +240,13 @@ module('Unit | Utils | attack', function (hooks) {
     );
     const expectedDmg: DamageDetails[] = [
       {
-        label: 'piercing (2d6 + 5 + 1d4)',
+        label: 'Piercing (2d6 + 5 + 1d4)',
         roll: 13,
         resisted: false,
         vulnerable: false,
       },
       {
-        label: 'radiant (2d8)',
+        label: 'Radiant (2d8)',
         roll: 7,
         resisted: false,
         vulnerable: false,
@@ -306,13 +306,13 @@ module('Unit | Utils | attack', function (hooks) {
     );
     const expectedDmg: DamageDetails[] = [
       {
-        label: 'piercing (2d6 + 5 + 1d4)',
+        label: 'Piercing (2d6 + 5 + 1d4)',
         roll: 25,
         resisted: false,
         vulnerable: false,
       },
       {
-        label: 'radiant (2d8)',
+        label: 'Radiant (2d8)',
         roll: 14,
         resisted: false,
         vulnerable: false,
@@ -322,6 +322,26 @@ module('Unit | Utils | attack', function (hooks) {
       attackData.damageDetails,
       expectedDmg,
       'damage details should match expectations'
+    );
+  });
+
+  test('it capitalizes words as expected', async function (assert) {
+    assert.strictEqual(
+      Attack.capitalizeWord(''),
+      '',
+      'empty string should be capitalized correctly'
+    );
+
+    assert.strictEqual(
+      Attack.capitalizeWord('a'),
+      'A',
+      'single letter should be capitalized correctly'
+    );
+
+    assert.strictEqual(
+      Attack.capitalizeWord('radiant'),
+      'Radiant',
+      'multi-letter word should be capitalized correctly'
     );
   });
 });


### PR DESCRIPTION
This capitalizes damage types when displaying the details of the damage inflicted by each attack, since these labels appear at the beginning of bullet points. It also updates the detail-display test to check its handling of toHit modifiers which begin with a sign (+ or -).