### PR TITLE
Lock version of 'util' package to match sinon's requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "timers-browserify": "^2.0.12",
     "tracked-built-ins": "^3.1.1",
     "typescript": "^5.1.3",
-    "util": "^0.10.4",
+    "util": "0.10.4",
     "webpack": "^5.78.0"
   },
   "engines": {


### PR DESCRIPTION
Sinon 15.1.2 uses version 0.10.4 of 'util'. It does not correctly configure the dependency now that webpack no longer uses polyfill; if 'util' is updated to 0.12.5, for instance, the tests error at runtime. When Sinon is updated, 'util' may also be able to be updated.