### PR TITLE
Remove clean-css since it is no longer needed after Ember upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4566,15 +4566,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@simple-dom/document": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@simple-dom/document/-/document-1.4.0.tgz",
-      "integrity": "sha512-/RUeVH4kuD3rzo5/91+h4Z1meLSLP66eXqpVAw/4aZmYozkeqUkMprq0znL4psX/adEed5cBgiNJcfMz/eKZLg==",
-      "dev": true,
-      "dependencies": {
-        "@simple-dom/interface": "^1.4.0"
-      }
-    },
     "node_modules/@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -9183,34 +9174,6 @@
       "resolved": "https://registry.npmjs.org/clean-base-url/-/clean-base-url-1.0.0.tgz",
       "integrity": "sha512-9q6ZvUAhbKOSRFY7A/irCQ/rF0KIpa3uXpx6izm8+fp7b2H4hLeUJ+F1YYk9+gDQ/X8Q0MEyYs+tG3cht//HTg==",
       "dev": true
-    },
-    "node_modules/clean-css": {
-      "version": "3.4.28",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
-      "integrity": "sha512-aTWyttSdI2mYi07kWqHi24NUU9YlELFKGOAgFzZjDN1064DMAOy2FBuoyGmkKRlXkbpXd0EVHmiVkbKhKoirTw==",
-      "dev": true,
-      "dependencies": {
-        "commander": "2.8.x",
-        "source-map": "0.4.x"
-      },
-      "bin": {
-        "cleancss": "bin/cleancss"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/commander": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-      "integrity": "sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-readlink": ">= 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6.x"
-      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -17138,12 +17101,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
-      "dev": true
-    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -19445,15 +19402,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minimist-options": {


### PR DESCRIPTION
This is based on a Dependabot PR which updated the ember-cli version only and then deleted clean-css from the package-lock file. Ember has been updated in a separate PR; this removes clean-css since there was a security concern with the library.