### PR TITLE
Temporarily update Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
     reviewers:
       - jbpeirce


### PR DESCRIPTION
As Dependabot updates have been paused for a couple of months, this temporarily updates dependabot to run daily so that maintainers can more easily catch up on dependency updates.