### PR TITLE
Increase number of PRs dependabot will open in parallel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "daily" # temporarily increase rate of PR filing from "weekly"
+    # temporarily increase the number of open PRs allowed from the default of 5
+    open-pull-requests-limit: 15
     reviewers:
       - jbpeirce


### PR DESCRIPTION
Since dependencies have not been updated for a few months, this increases the number of PRs dependabot can open in parallel.