### PR TITLE
Simplify display

### DIFF
--- a/app/components/damage-type.hbs
+++ b/app/components/damage-type.hbs
@@ -5,9 +5,6 @@
       aria-describedby="dmgDescription-{{@index}}" @value={{@initialDamage}} {{on "input" @setDamage}}
       pattern={{this.diceGroupsRegex}}
       title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
-    {{!-- <small id="dmgDescription-{{@index}}" class="form-text text-muted">
-      A string of the form 'XdY+Z' or 'XdY-Z' (ex: 3d8+4).
-    </small> --}}
   </div>
 </div>
 

--- a/app/components/damage-type.hbs
+++ b/app/components/damage-type.hbs
@@ -5,9 +5,9 @@
       aria-describedby="dmgDescription-{{@index}}" @value={{@initialDamage}} {{on "input" @setDamage}}
       pattern={{this.diceGroupsRegex}}
       title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
-    <small id="dmgDescription-{{@index}}" class="form-text text-muted">
+    {{!-- <small id="dmgDescription-{{@index}}" class="form-text text-muted">
       A string of the form 'XdY+Z' or 'XdY-Z' (ex: 3d8+4).
-    </small>
+    </small> --}}
   </div>
 </div>
 

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -28,27 +28,31 @@
 </h4>
 <ol data-test-attack-detail-list>
   {{#each @attackDetailsList as |attackDetails index|}}
-  <li>
-    Attack
-    {{#if attackDetails.hit }}
-    inflicted {{attackDetails.damage}} damage
-    {{/if}}
-    {{#unless attackDetails.hit}}
-    missed
-    {{/unless}}
-    with an attack roll of {{attackDetails.roll}}
+
+  {{#if attackDetails.hit }}
+  <hit>
+    Attack roll: {{attackDetails.roll}}
     {{#if attackDetails.crit}} (CRIT!){{/if}}
-    {{#if attackDetails.nat1}} (NAT 1!){{/if}}
+
     <ul data-test-damage-detail-list={{index}}>
       {{#each attackDetails.damageDetails as |damage|}}
       <li>
-        {{damage.label}}: {{damage.roll}} damage
+        {{damage.label}}: {{damage.roll}} damage inflicted
         {{#if damage.resisted}} (resisted){{/if}}
         {{#if damage.vulnerable}} (vulnerable){{/if}}
       </li>
       {{/each}}
     </ul>
-  </li>
+  </hit>
+  {{/if}}
+
+  {{#unless attackDetails.hit }}
+  <miss>
+    Attack roll: {{attackDetails.roll}}
+    {{#if attackDetails.nat1}} (NAT 1!){{/if}}
+  </miss>
+  {{/unless}}
+
   {{/each}}
 </ol>
 {{/if}}

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -30,7 +30,7 @@
   {{#each @attackDetailsList as |attackDetails index|}}
 
   {{#if attackDetails.hit }}
-  <hit>
+  <li class="li-hit">
     Attack roll: {{attackDetails.roll}}
     {{#if attackDetails.crit}} (CRIT!){{/if}}
 
@@ -43,14 +43,14 @@
       </li>
       {{/each}}
     </ul>
-  </hit>
+  </li>
   {{/if}}
 
   {{#unless attackDetails.hit }}
-  <miss>
+  <li class="li-miss">
     Attack roll: {{attackDetails.roll}}
     {{#if attackDetails.nat1}} (NAT 1!){{/if}}
-  </miss>
+  </li>
   {{/unless}}
 
   {{/each}}

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -29,11 +29,13 @@
           <Input data-test-input-toHit class="form-control" @type="text" id="toHit" name="toHit" @value={{this.toHit}}
             aria-describedby="toHitDescription" pattern={{this.diceGroupsRegex}}
             title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
-          <small id="toHitDescription" class="form-text text-muted">
+          {{!-- <small id="toHitDescription" class="form-text text-muted">
             A number or a string of the form 'XdY+Z' or 'XdY-Z' (ex: 5 + 1d4).
-          </small>
+          </small> --}}
         </div>
       </div>
+      <hr>
+
 
       {{#each this.damageList as |damage index| }}
       <DamageType data-test-damage-type={{index}} @index={{index}} @setDamage={{damage.setDamage}}

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -29,9 +29,6 @@
           <Input data-test-input-toHit class="form-control" @type="text" id="toHit" name="toHit" @value={{this.toHit}}
             aria-describedby="toHitDescription" pattern={{this.diceGroupsRegex}}
             title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
-          {{!-- <small id="toHitDescription" class="form-text text-muted">
-            A number or a string of the form 'XdY+Z' or 'XdY-Z' (ex: 5 + 1d4).
-          </small> --}}
         </div>
       </div>
       <hr>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,1 +1,21 @@
 /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
+
+hit {
+  display: list-item;
+  padding-inline-start: 1ch;
+}
+
+hit::marker {
+  color: green;
+  content: "✓";
+}
+
+miss {
+  display: list-item;
+  padding-inline-start: 1ch;
+}
+
+miss::marker {
+  color: red;
+  content: "✕";
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,21 +1,19 @@
 /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
 
-hit {
-  display: list-item;
+.li-hit {
   padding-inline-start: 1ch;
 }
 
-hit::marker {
+.li-hit::marker {
   color: green;
   content: "✓";
 }
 
-miss {
-  display: list-item;
+.li-miss {
   padding-inline-start: 1ch;
 }
 
-miss::marker {
+.li-miss::marker {
   color: red;
   content: "✕";
 }

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -52,17 +52,38 @@ module('Integration | Component | detail-display', function (hooks) {
         hit: true,
         crit: true,
         nat1: false,
-        damage: 22,
+        damage: 37,
         damageDetails: [
           {
             label: 'piercing (2d6 + 5 + 1d4)',
-            roll: 8,
+            roll: 11,
             resisted: true,
             vulnerable: false,
           },
           {
             label: 'radiant (2d8)',
-            roll: 14,
+            roll: 26,
+            resisted: false,
+            vulnerable: true,
+          },
+        ],
+      },
+      {
+        roll: 18,
+        hit: true,
+        crit: false,
+        nat1: false,
+        damage: 25,
+        damageDetails: [
+          {
+            label: 'piercing (2d6 + 5 + 1d4)',
+            roll: 5,
+            resisted: true,
+            vulnerable: false,
+          },
+          {
+            label: 'radiant (2d8)',
+            roll: 20,
             resisted: false,
             vulnerable: true,
           },
@@ -102,7 +123,7 @@ module('Integration | Component | detail-display', function (hooks) {
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{22}} @attackDetailsList={{this.attackDetails}} />`,
+      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{62}} @attackDetailsList={{this.attackDetails}} />`,
     );
 
     assert
@@ -121,7 +142,7 @@ module('Integration | Component | detail-display', function (hooks) {
 
     assert
       .dom('[data-test-total-damage-header]')
-      .hasText('*** Total Damage: 22 ***');
+      .hasText('*** Total Damage: 62 ***');
 
     assert
       .dom('[data-test-attack-detail-list]')
@@ -134,88 +155,125 @@ module('Integration | Component | detail-display', function (hooks) {
     if (detailsList) {
       assert.equal(
         detailsList.length,
-        5,
-        '5 attacks should have been displayed',
+        6,
+        '6 attacks should have been displayed',
       );
 
       assert.equal(
-        detailsList[0]?.tagName?.toLowerCase(),
-        'hit',
+        detailsList[0]?.className,
+        'li-hit',
         'critical hit should have bullet point formatted as a hit',
       );
       assert.equal(
         detailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 25 (CRIT!) piercing (2d6 + 5 + 1d4): 8 damage inflicted (resisted) radiant (2d8): 14 damage inflicted (vulnerable)',
+        'Attack roll: 25 (CRIT!) piercing (2d6 + 5 + 1d4): 11 damage inflicted (resisted) radiant (2d8): 26 damage inflicted (vulnerable)',
         'critical hit should have expected detail text',
       );
 
       assert.equal(
-        detailsList[1]?.tagName?.toLowerCase(),
-        'miss',
-        'negative attack roll should have bullet point formatted as a miss',
+        detailsList[1]?.className,
+        'li-hit',
+        'normal hit should have bullet point formatted as a hit',
       );
       assert.equal(
         detailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
+        'Attack roll: 18 piercing (2d6 + 5 + 1d4): 5 damage inflicted (resisted) radiant (2d8): 20 damage inflicted (vulnerable)',
+        'normal hit should have expected detail text',
+      );
+
+      assert.equal(
+        detailsList[2]?.className,
+        'li-miss',
+        'negative attack roll should have bullet point formatted as a miss',
+      );
+      assert.equal(
+        detailsList[2]?.textContent?.trim().replace(/\s+/g, ' '),
         'Attack roll: -4',
         'negative attack roll should have expected detail text',
       );
 
       assert.equal(
-        detailsList[2]?.tagName?.toLowerCase(),
-        'miss',
+        detailsList[3]?.className,
+        'li-miss',
         'double-digit attack roll with a miss should have bullet point formatted as a miss',
       );
       assert.equal(
-        detailsList[2]?.textContent?.trim().replace(/\s+/g, ' '),
+        detailsList[3]?.textContent?.trim().replace(/\s+/g, ' '),
         'Attack roll: 13',
         'double-digit attack roll with a miss should have expected detail text',
       );
 
       assert.equal(
-        detailsList[3]?.tagName?.toLowerCase(),
-        'miss',
+        detailsList[4]?.className,
+        'li-miss',
         'natural one should have bullet point formatted as a miss',
       );
       assert.equal(
-        detailsList[3]?.textContent?.trim().replace(/\s+/g, ' '),
+        detailsList[4]?.textContent?.trim().replace(/\s+/g, ' '),
         'Attack roll: -5 (NAT 1!)',
         'natural one should have expected detail text',
       );
 
       assert.equal(
-        detailsList[4]?.tagName?.toLowerCase(),
-        'miss',
+        detailsList[5]?.className,
+        'li-miss',
         'single-digit attack roll with a miss should have bullet point formatted as a miss',
       );
       assert.equal(
-        detailsList[4]?.textContent?.trim().replace(/\s+/g, ' '),
+        detailsList[5]?.textContent?.trim().replace(/\s+/g, ' '),
         'Attack roll: 6',
         'single-digit attack roll with a miss should have expected detail text',
       );
     }
 
-    const damageDetailsList = this.element.querySelector(
+    const critDamageDetailsList = this.element.querySelector(
       '[data-test-damage-detail-list="0"]',
     )?.children;
     assert.true(
-      damageDetailsList != null,
+      critDamageDetailsList != null,
       'damage detail list should be present',
     );
-    if (damageDetailsList) {
+    if (critDamageDetailsList) {
       assert.equal(
-        damageDetailsList.length,
+        critDamageDetailsList.length,
         2,
         '2 types of damage should have been displayed',
       );
 
       assert.equal(
-        damageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'piercing (2d6 + 5 + 1d4): 8 damage inflicted (resisted)',
+        critDamageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
+        'piercing (2d6 + 5 + 1d4): 11 damage inflicted (resisted)',
         'piercing damage details should be displayed',
       );
       assert.equal(
-        damageDetailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
-        'radiant (2d8): 14 damage inflicted (vulnerable)',
+        critDamageDetailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
+        'radiant (2d8): 26 damage inflicted (vulnerable)',
+        'radiant damage details should be displayed',
+      );
+    }
+
+    const regularDamageDetailsList = this.element.querySelector(
+      '[data-test-damage-detail-list="1"]',
+    )?.children;
+    assert.true(
+      regularDamageDetailsList != null,
+      'damage detail list should be present',
+    );
+    if (regularDamageDetailsList) {
+      assert.equal(
+        regularDamageDetailsList.length,
+        2,
+        '2 types of damage should have been displayed',
+      );
+
+      assert.equal(
+        regularDamageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
+        'piercing (2d6 + 5 + 1d4): 5 damage inflicted (resisted)',
+        'piercing damage details should be displayed',
+      );
+      assert.equal(
+        regularDamageDetailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
+        'radiant (2d8): 20 damage inflicted (vulnerable)',
         'radiant damage details should be displayed',
       );
     }

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -139,29 +139,58 @@ module('Integration | Component | detail-display', function (hooks) {
       );
 
       assert.equal(
+        detailsList[0]?.tagName?.toLowerCase(),
+        'hit',
+        'critical hit should have bullet point formatted as a hit',
+      );
+      assert.equal(
         detailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack inflicted 22 damage with an attack roll of 25 (CRIT!) piercing (2d6 + 5 + 1d4): 8 damage (resisted) radiant (2d8): 14 damage (vulnerable)',
-        'critical hit should be correctly displayed',
+        'Attack roll: 25 (CRIT!) piercing (2d6 + 5 + 1d4): 8 damage inflicted (resisted) radiant (2d8): 14 damage inflicted (vulnerable)',
+        'critical hit should have expected detail text',
+      );
+
+      assert.equal(
+        detailsList[1]?.tagName?.toLowerCase(),
+        'miss',
+        'negative attack roll should have bullet point formatted as a miss',
       );
       assert.equal(
         detailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack missed with an attack roll of -4',
-        'negative attack roll should be properly displayed',
+        'Attack roll: -4',
+        'negative attack roll should have expected detail text',
+      );
+
+      assert.equal(
+        detailsList[2]?.tagName?.toLowerCase(),
+        'miss',
+        'double-digit attack roll with a miss should have bullet point formatted as a miss',
       );
       assert.equal(
         detailsList[2]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack missed with an attack roll of 13',
-        'double-digit attack roll with a miss should be properly displayed',
+        'Attack roll: 13',
+        'double-digit attack roll with a miss should have expected detail text',
+      );
+
+      assert.equal(
+        detailsList[3]?.tagName?.toLowerCase(),
+        'miss',
+        'natural one should have bullet point formatted as a miss',
       );
       assert.equal(
         detailsList[3]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack missed with an attack roll of -5 (NAT 1!)',
-        'natural one should be correctly displayed',
+        'Attack roll: -5 (NAT 1!)',
+        'natural one should have expected detail text',
+      );
+
+      assert.equal(
+        detailsList[4]?.tagName?.toLowerCase(),
+        'miss',
+        'single-digit attack roll with a miss should have bullet point formatted as a miss',
       );
       assert.equal(
         detailsList[4]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack missed with an attack roll of 6',
-        'single-digit attack roll with a miss should be properly displayed',
+        'Attack roll: 6',
+        'single-digit attack roll with a miss should have expected detail text',
       );
     }
 
@@ -181,12 +210,12 @@ module('Integration | Component | detail-display', function (hooks) {
 
       assert.equal(
         damageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'piercing (2d6 + 5 + 1d4): 8 damage (resisted)',
+        'piercing (2d6 + 5 + 1d4): 8 damage inflicted (resisted)',
         'piercing damage details should be displayed',
       );
       assert.equal(
         damageDetailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
-        'radiant (2d8): 14 damage (vulnerable)',
+        'radiant (2d8): 14 damage inflicted (vulnerable)',
         'radiant damage details should be displayed',
       );
     }


### PR DESCRIPTION
This removes unnecessary formatting hints (which became redundant with the addition of placeholder text and hover text) and simplifies the display of detailed attacks to make it more concise.

![image](https://github.com/jbpeirce/multiattack-5e/assets/13395970/1c36de16-1456-4534-917c-d0ea9e591c4b)
