### PR TITLE
Display the number of successful hits in the attack summary

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -24,7 +24,7 @@
 </ul>
 {{#if @attackTriggered}}
 <h4 data-test-total-damage-header>
-  <strong>*** Total Damage: {{@totalDmg}} ***</strong>
+  <strong>*** Total Damage: {{@totalDmg}} ({{@numberOfHits}} {{this.getHitString @numberOfHits}}) ***</strong>
 </h4>
 <ol data-test-attack-detail-list>
   {{#each @attackDetailsList as |attackDetails index|}}

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -21,4 +21,19 @@ export default class DetailDisplayComponent extends Component {
       return `1d20 + ${toHit}`;
     }
   };
+
+  /**
+   * Use the given number of hits to return either "hits" or "hit" as
+   * appropriate
+   * @param numberOfHits the number of hits involved
+   * @returns "hit" or "hits" depending on whether numberOfHits is greater than
+   * one
+   */
+  getHitString = (numberOfHits: number) => {
+    if (numberOfHits == 1) {
+      return 'hit';
+    } else {
+      return 'hits';
+    }
+  };
 }

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -65,6 +65,6 @@
   <div class="col-md">
     <DetailDisplay @targetAC={{this.targetAC}} @numberOfAttacks={{this.numberOfAttacks}} @toHit={{this.toHit}}
       @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{this.attackTriggered}}
-      @totalDmg={{this.totalDmg}} @attackDetailsList={{this.attackDetailsList}} />
+      @totalDmg={{this.totalDmg}} @numberOfHits={{this.totalNumberOfHits}} @attackDetailsList={{this.attackDetailsList}} />
   </div>
 </div>

--- a/app/components/repeated-attack-form.ts
+++ b/app/components/repeated-attack-form.ts
@@ -23,6 +23,7 @@ export default class RepeatedAttackFormComponent extends Component {
 
   @tracked attackTriggered = false;
   @tracked totalDmg = 0;
+  @tracked totalNumberOfHits = 0;
   @tracked attackDetailsList: AttackDetails[] = [];
 
   diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
@@ -64,6 +65,7 @@ export default class RepeatedAttackFormComponent extends Component {
   simulateRepeatedAttacks = () => {
     this.attackTriggered = true;
     this.totalDmg = 0;
+    this.totalNumberOfHits = 0;
     this.attackDetailsList = [];
 
     const attack = new Attack(this.toHit, this.damageList.toArray());
@@ -76,6 +78,7 @@ export default class RepeatedAttackFormComponent extends Component {
       );
 
       this.totalDmg += attackDetails.damage;
+      this.totalNumberOfHits += attackDetails.numberOfHits;
       this.attackDetailsList.push(attackDetails);
     }
   };

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -9,6 +9,7 @@ export interface AttackDetails {
   crit: boolean;
   nat1: boolean;
   damage: number;
+  numberOfHits: number;
   damageDetails: DamageDetails[];
 }
 
@@ -62,12 +63,14 @@ export default class Attack {
     const nat1 = attackD20 == 1;
 
     let totalDmg = 0;
+    let numberOfHits = 0;
     const damageDetails: DamageDetails[] = [];
 
     // Attacks always miss on a nat1, always hit on a crit, and otherwise hit if
     // the roll equals or exceeds the target AC.
     const hit = !nat1 && (crit || attackRoll >= targetAC);
     if (hit) {
+      numberOfHits += 1;
       for (const damage of this.damageTypes) {
         const rolledDmg = damage.roll(crit);
         totalDmg += rolledDmg;
@@ -88,6 +91,7 @@ export default class Attack {
       crit: crit,
       nat1: nat1,
       damage: totalDmg,
+      numberOfHits: numberOfHits,
       damageDetails: damageDetails,
     };
   }

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -123,7 +123,7 @@ module('Integration | Component | detail-display', function (hooks) {
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{62}} @attackDetailsList={{this.attackDetails}} />`,
+      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{62}} @numberOfHits={{2}} @attackDetailsList={{this.attackDetails}} />`,
     );
 
     assert
@@ -142,7 +142,7 @@ module('Integration | Component | detail-display', function (hooks) {
 
     assert
       .dom('[data-test-total-damage-header]')
-      .hasText('*** Total Damage: 62 ***');
+      .hasText('*** Total Damage: 62 (2 hits) ***');
 
     assert
       .dom('[data-test-attack-detail-list]')
@@ -277,5 +277,68 @@ module('Integration | Component | detail-display', function (hooks) {
         'radiant damage details should be displayed',
       );
     }
+  });
+
+  test('it renders a single attack correctly', async function (this: ElementContext, assert) {
+    this.set('advantageState', AdvantageState.ADVANTAGE);
+    this.set('attackDetails', [
+      {
+        roll: 18,
+        hit: true,
+        crit: false,
+        nat1: false,
+        damage: 25,
+        damageDetails: [
+          {
+            label: 'piercing (2d6 + 5 + 1d4)',
+            roll: 5,
+            resisted: true,
+            vulnerable: false,
+          },
+          {
+            label: 'radiant (2d8)',
+            roll: 20,
+            resisted: false,
+            vulnerable: true,
+          },
+        ],
+      },
+      {
+        roll: -4,
+        hit: false,
+        crit: false,
+        nat1: false,
+        damage: 0,
+      },
+    ]);
+    this.set('damageList', [
+      new Damage('2d6 + 5', DamageType.ACID.name, true, true),
+    ]);
+
+    await render(
+      hbs`<DetailDisplay @numberOfAttacks={{2}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{25}} @numberOfHits={{1}} @attackDetailsList={{this.attackDetails}} />`,
+    );
+
+    assert
+      .dom('[data-test-plan-detail-list]')
+      .hasText(
+        'Target AC: 15\n' +
+          'Number of attacks: 2\n' +
+          'Attack roll: 1d20 + 3 - 1d6 (rolls with advantage)\n' +
+          'Attack damage: 2d6 + 5 acid damage (target resistant) (target vulnerable)',
+        'the details for the input damage should be displayed',
+      );
+
+    assert
+      .dom('[data-test-total-damage-header]')
+      .isVisible('damage header should be displayed');
+
+    assert
+      .dom('[data-test-total-damage-header]')
+      .hasText('*** Total Damage: 25 (1 hit) ***');
+
+    assert
+      .dom('[data-test-attack-detail-list]')
+      .isVisible('attack details should be displayed');
   });
 });


### PR DESCRIPTION
This displays how many hits were successful as well as the total damage in the summary of an attack. This is useful for situations where additional action must be taken on a successful hit, such as a constitution save against poison or lycanthropy, since it makes it easy to count how many saves should be made.