### PR TITLE
Add log of previous repeated attacks

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -1,58 +1,58 @@
-<h4>
-  Attack Details
-</h4>
-<ul data-test-plan-detail-list>
-  <li>Target AC: {{@targetAC}}</li>
-  <li>Number of attacks: {{@numberOfAttacks}}</li>
-  <li>Attack roll: {{this.getAttackString @toHit}}
-    {{#if (eq @advantageState.name "advantage") }}
-    (rolls with advantage)
-    {{/if}}
-    {{#if (eq @advantageState.name "disadvantage") }}
-    (rolls with disadvantage)
-    {{/if}}
-  </li>
-  <li>Attack damage:</li>
-  <ul data-test-plan-detail-damage-list>
-    {{#each @damageList as |damage|}}
-    <li>{{damage.damageString}} {{damage.type}} damage
-      {{#if damage.targetResistant}} (target resistant){{/if}}
-      {{#if damage.targetVulnerable}} (target vulnerable){{/if}}
+<h3 data-test-log-header>
+  Attack Log
+</h3>
+<ul data-test-attack-log>
+  {{#each @repeatedAttackLog as |repeatedAttackDetails index|}}
+  <h5 data-test-attack-data-header={{index}}>
+    Attack Data
+  </h5>
+  <ul data-test-attack-data-list={{index}}>
+    <li>Number of attacks: {{repeatedAttackDetails.numberOfAttacks}}</li>
+    <li>Target AC: {{repeatedAttackDetails.targetAC}}</li>
+    <li>Attack roll: {{this.getAttackString repeatedAttackDetails.toHit}}
+      {{#if (eq repeatedAttackDetails.advantageState.name "advantage") }}
+      (advantage)
+      {{/if}}
+      {{#if (eq repeatedAttackDetails.advantageState.name "disadvantage") }}
+      (disadvantage)
+      {{/if}}
     </li>
-    {{/each}}
   </ul>
-</ul>
-{{#if @attackTriggered}}
-<h4 data-test-total-damage-header>
-  <strong>*** Total Damage: {{@totalDmg}} ({{@numberOfHits}} {{this.getHitString @numberOfHits}}) ***</strong>
-</h4>
-<ol data-test-attack-detail-list>
-  {{#each @attackDetailsList as |attackDetails index|}}
+  <h4 data-test-total-damage-header={{index}}>
+    <strong>*** Total Damage: {{repeatedAttackDetails.totalDmg}} ({{repeatedAttackDetails.totalNumberOfHits}}
+      {{this.getHitString repeatedAttackDetails.totalNumberOfHits}}) ***</strong>
+  </h4>
+  <ol data-test-attack-detail-list={{index}}>
+    {{#each repeatedAttackDetails.attackDetailsList as |attackDetails index2|}}
 
-  {{#if attackDetails.hit }}
-  <li class="li-hit">
-    Attack roll: {{attackDetails.roll}}
-    {{#if attackDetails.crit}} (CRIT!){{/if}}
+    {{#if attackDetails.hit }}
+    <li class="li-hit">
+      Attack roll: {{attackDetails.roll}}
+      {{#if attackDetails.crit}} (CRIT!){{/if}}
 
-    <ul data-test-damage-detail-list={{index}}>
-      {{#each attackDetails.damageDetails as |damage|}}
-      <li>
-        {{damage.label}}: {{damage.roll}} damage inflicted
-        {{#if damage.resisted}} (resisted){{/if}}
-        {{#if damage.vulnerable}} (vulnerable){{/if}}
-      </li>
-      {{/each}}
-    </ul>
-  </li>
-  {{/if}}
+      <ul data-test-damage-detail-list="{{index}}-{{index2}}">
+        {{#each attackDetails.damageDetails as |damage|}}
+        <li>
+          {{damage.label}}: {{damage.roll}} damage inflicted
+          {{#if damage.resisted}} (resisted){{/if}}
+          {{#if damage.vulnerable}} (vulnerable){{/if}}
+        </li>
+        {{/each}}
+      </ul>
+    </li>
+    {{/if}}
 
-  {{#unless attackDetails.hit }}
-  <li class="li-miss">
-    Attack roll: {{attackDetails.roll}}
-    {{#if attackDetails.nat1}} (NAT 1!){{/if}}
-  </li>
-  {{/unless}}
+    {{#unless attackDetails.hit }}
+    <li class="li-miss">
+      Attack roll: {{attackDetails.roll}}
+      {{#if attackDetails.nat1}} (NAT 1!){{/if}}
+    </li>
+    {{/unless}}
 
+    {{/each}}
+  </ol>
+  <hr>
+  <hr>
+  <hr>
   {{/each}}
-</ol>
-{{/if}}
+</ul>

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -1,7 +1,7 @@
 <div class="row align-items-top">
   <div class="col-sm">
     <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
-      <h2>Set Up Current Attacks</h2>
+      <h2>Set Up Attacks</h2>
       <div class="row align-items-top">
         <div class="col">
           <label for="numberOfAttacks">Number of Attacks</label>
@@ -22,7 +22,7 @@
         </div>
       </div>
 
-      <h3 class="mt-3">Enter Attack Details</h3>
+      <h3 class="mt-3" data-test-enter-details-header>Enter Attack Details</h3>
       <div class="row align-items-top">
         <div class="col">
           <label for="toHit">To Hit Modifier</label>
@@ -62,9 +62,7 @@
     </form>
   </div>
 
-  <div class="col-md">
-    <DetailDisplay @targetAC={{this.targetAC}} @numberOfAttacks={{this.numberOfAttacks}} @toHit={{this.toHit}}
-      @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{this.attackTriggered}}
-      @totalDmg={{this.totalDmg}} @numberOfHits={{this.totalNumberOfHits}} @attackDetailsList={{this.attackDetailsList}} />
+  <div class="col-md col-scrollable">
+    <DetailDisplay @repeatedAttackLog={{this.attackResultLog}} />
   </div>
 </div>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -17,3 +17,8 @@
   color: red;
   content: "✕";
 }
+
+.col-scrollable {
+  overflow-y: scroll;
+  max-height: calc(100vh - 15px);
+}

--- a/app/utils/repeated-attack.ts
+++ b/app/utils/repeated-attack.ts
@@ -1,0 +1,82 @@
+import AdvantageState from 'multiattack-5e/components/advantage-state-enum';
+
+import Attack, { type AttackDetails } from './attack';
+import type Damage from './damage';
+
+export interface RepeatedAttackResult {
+  // the parameters for this set of attacks
+  numberOfAttacks: number;
+  targetAC: number;
+  toHit: string;
+  damageList: Damage[];
+  advantageState: AdvantageState;
+
+  // the results of executing the repeated attacks
+  totalDmg: number;
+  totalNumberOfHits: number;
+  attackDetailsList: AttackDetails[];
+}
+
+export default class RepeatedAttack {
+  numberOfAttacks: number;
+  targetAC: number;
+
+  toHit: string;
+  damageList: Damage[];
+  advantageState: AdvantageState;
+
+  constructor(
+    numberOfAttacks: number,
+    targetAC: number,
+    toHit: string,
+    damageList: Damage[],
+    advantageState: AdvantageState,
+  ) {
+    this.numberOfAttacks = numberOfAttacks;
+    this.targetAC = targetAC;
+    this.toHit = toHit;
+    this.damageList = damageList;
+    this.advantageState = advantageState;
+  }
+
+  /**
+   * Simulate attacks against a target with a given AC, with the details of the
+   * attack specified by the constructor for this class. This method may
+   * produce significantly different results on repeated calls, since it relies
+   * heavily on the randomness of simulated dice.
+   *
+   * @returns a summary of the result of simulating repeated attacks with the
+   * given parameters
+   */
+  simulateRepeatedAttacks(): RepeatedAttackResult {
+    let totalDmg = 0;
+    let totalNumberOfHits = 0;
+    const attackDetailsList = [];
+
+    const attack = new Attack(this.toHit, this.damageList.toArray());
+
+    for (let i = 0; i < this.numberOfAttacks; i++) {
+      const attackDetails = attack.makeAttack(
+        this.targetAC,
+        this.advantageState == AdvantageState.ADVANTAGE,
+        this.advantageState == AdvantageState.DISADVANTAGE,
+      );
+
+      totalDmg += attackDetails.damage;
+      totalNumberOfHits += attackDetails.numberOfHits;
+      attackDetailsList.push(attackDetails);
+    }
+
+    return {
+      numberOfAttacks: this.numberOfAttacks,
+      targetAC: this.targetAC,
+      toHit: this.toHit,
+      damageList: this.damageList,
+      advantageState: this.advantageState,
+
+      totalDmg: totalDmg,
+      totalNumberOfHits: totalNumberOfHits,
+      attackDetailsList: attackDetailsList,
+    };
+  }
+}

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -11,145 +11,121 @@ import Damage from 'multiattack-5e/utils/damage';
 module('Integration | Component | detail-display', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders planned attack details before any attack', async function (this: ElementContext, assert) {
-    this.set('advantageState', AdvantageState.DISADVANTAGE);
-    this.set('damageList', [
-      new Damage('2d6 + 5', DamageType.ACID.name, true, true),
-    ]);
-
-    await render(
-      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="- 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{false}} />`,
-    );
-
-    assert
-      .dom('[data-test-plan-detail-list]')
-      .hasText(
-        'Target AC: 15\n' +
-          'Number of attacks: 8\n' +
-          'Attack roll: 1d20 - 1d6 (rolls with disadvantage)\n' +
-          'Attack damage: 2d6 + 5 acid damage (target resistant) (target vulnerable)',
-        'the details for the input damage should be displayed',
-      );
-
-    const damageList = this.element.querySelector(
-      '[data-test-plan-detail-damage-list]',
-    )?.children;
-    assert.equal(damageList?.length, 1, 'damage list should have one entry');
-    if (damageList) {
-      assert.equal(
-        damageList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        '2d6 + 5 acid damage (target resistant) (target vulnerable)',
-        'acid damage details should be displayed',
-      );
-    }
-  });
-
-  test('it renders attack details after the attack', async function (this: ElementContext, assert) {
-    this.set('advantageState', AdvantageState.DISADVANTAGE);
-    this.set('attackDetails', [
+  test('it renders multiple hits and misses in a single repeated attack', async function (this: ElementContext, assert) {
+    this.set('repeatedAttackDetails', [
       {
-        roll: 25,
-        hit: true,
-        crit: true,
-        nat1: false,
-        damage: 37,
-        damageDetails: [
+        numberOfAttacks: 8,
+        targetAC: 15,
+        toHit: '3 - 1d6',
+        damageList: [
+          new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name, true, false),
+          new Damage('2d8', DamageType.RADIANT.name, false, true),
+        ],
+        advantageState: AdvantageState.DISADVANTAGE,
+        totalDmg: 62,
+        totalNumberOfHits: 2,
+        attackDetailsList: [
           {
-            label: 'piercing (2d6 + 5 + 1d4)',
-            roll: 11,
-            resisted: true,
-            vulnerable: false,
+            roll: 25,
+            hit: true,
+            crit: true,
+            nat1: false,
+            damage: 37,
+            damageDetails: [
+              {
+                label: 'piercing (2d6 + 5 + 1d4)',
+                roll: 11,
+                resisted: true,
+                vulnerable: false,
+              },
+              {
+                label: 'radiant (2d8)',
+                roll: 26,
+                resisted: false,
+                vulnerable: true,
+              },
+            ],
           },
           {
-            label: 'radiant (2d8)',
-            roll: 26,
-            resisted: false,
-            vulnerable: true,
+            roll: 18,
+            hit: true,
+            crit: false,
+            nat1: false,
+            damage: 25,
+            damageDetails: [
+              {
+                label: 'piercing (2d6 + 5 + 1d4)',
+                roll: 5,
+                resisted: true,
+                vulnerable: false,
+              },
+              {
+                label: 'radiant (2d8)',
+                roll: 20,
+                resisted: false,
+                vulnerable: true,
+              },
+            ],
+          },
+          {
+            roll: -4,
+            hit: false,
+            crit: false,
+            nat1: false,
+            damage: 0,
+          },
+          {
+            roll: 13,
+            hit: false,
+            crit: false,
+            nat1: false,
+            damage: 0,
+          },
+          {
+            roll: -5,
+            hit: false,
+            crit: false,
+            nat1: true,
+            damage: 0,
+          },
+          {
+            roll: 6,
+            hit: false,
+            crit: false,
+            nat1: false,
+            damage: 0,
           },
         ],
       },
-      {
-        roll: 18,
-        hit: true,
-        crit: false,
-        nat1: false,
-        damage: 25,
-        damageDetails: [
-          {
-            label: 'piercing (2d6 + 5 + 1d4)',
-            roll: 5,
-            resisted: true,
-            vulnerable: false,
-          },
-          {
-            label: 'radiant (2d8)',
-            roll: 20,
-            resisted: false,
-            vulnerable: true,
-          },
-        ],
-      },
-      {
-        roll: -4,
-        hit: false,
-        crit: false,
-        nat1: false,
-        damage: 0,
-      },
-      {
-        roll: 13,
-        hit: false,
-        crit: false,
-        nat1: false,
-        damage: 0,
-      },
-      {
-        roll: -5,
-        hit: false,
-        crit: false,
-        nat1: true,
-        damage: 0,
-      },
-      {
-        roll: 6,
-        hit: false,
-        crit: false,
-        nat1: false,
-        damage: 0,
-      },
-    ]);
-    this.set('damageList', [
-      new Damage('2d6 + 5', DamageType.ACID.name, true, true),
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks={{8}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{62}} @numberOfHits={{2}} @attackDetailsList={{this.attackDetails}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} />`,
     );
 
     assert
-      .dom('[data-test-plan-detail-list]')
+      .dom('[data-test-attack-data-list="0"]')
       .hasText(
-        'Target AC: 15\n' +
-          'Number of attacks: 8\n' +
-          'Attack roll: 1d20 + 3 - 1d6 (rolls with disadvantage)\n' +
-          'Attack damage: 2d6 + 5 acid damage (target resistant) (target vulnerable)',
+        'Number of attacks: 8\n' +
+          'Target AC: 15\n' +
+          'Attack roll: 1d20 + 3 - 1d6 (disadvantage)\n',
         'the details for the input damage should be displayed',
       );
 
     assert
-      .dom('[data-test-total-damage-header]')
+      .dom('[data-test-total-damage-header="0"]')
       .isVisible('damage header should be displayed');
 
     assert
-      .dom('[data-test-total-damage-header]')
+      .dom('[data-test-total-damage-header="0"]')
       .hasText('*** Total Damage: 62 (2 hits) ***');
 
     assert
-      .dom('[data-test-attack-detail-list]')
+      .dom('[data-test-attack-detail-list="0"]')
       .isVisible('attack details should be displayed');
 
     const detailsList = this.element.querySelector(
-      '[data-test-attack-detail-list]',
+      '[data-test-attack-detail-list="0"]',
     )?.children;
     assert.true(detailsList != null, 'detail list should be present');
     if (detailsList) {
@@ -227,7 +203,7 @@ module('Integration | Component | detail-display', function (hooks) {
     }
 
     const critDamageDetailsList = this.element.querySelector(
-      '[data-test-damage-detail-list="0"]',
+      '[data-test-damage-detail-list="0-0"]',
     )?.children;
     assert.true(
       critDamageDetailsList != null,
@@ -253,7 +229,7 @@ module('Integration | Component | detail-display', function (hooks) {
     }
 
     const regularDamageDetailsList = this.element.querySelector(
-      '[data-test-damage-detail-list="1"]',
+      '[data-test-damage-detail-list="0-1"]',
     )?.children;
     assert.true(
       regularDamageDetailsList != null,
@@ -279,66 +255,238 @@ module('Integration | Component | detail-display', function (hooks) {
     }
   });
 
-  test('it renders a single attack correctly', async function (this: ElementContext, assert) {
-    this.set('advantageState', AdvantageState.ADVANTAGE);
-    this.set('attackDetails', [
+  test('it renders a single hit correctly', async function (this: ElementContext, assert) {
+    this.set('repeatedAttackDetails', [
       {
-        roll: 18,
-        hit: true,
-        crit: false,
-        nat1: false,
-        damage: 25,
-        damageDetails: [
+        numberOfAttacks: 2,
+        targetAC: 15,
+        toHit: '-3',
+        damageList: [
+          new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name, true, false),
+          new Damage('2d8', DamageType.RADIANT.name, false, true),
+        ],
+        advantageState: AdvantageState.STRAIGHT,
+        totalDmg: 25,
+        totalNumberOfHits: 1,
+        attackDetailsList: [
           {
-            label: 'piercing (2d6 + 5 + 1d4)',
-            roll: 5,
-            resisted: true,
-            vulnerable: false,
+            roll: 18,
+            hit: true,
+            crit: false,
+            nat1: false,
+            damage: 25,
+            damageDetails: [
+              {
+                label: 'piercing (2d6 + 5 + 1d4)',
+                roll: 5,
+                resisted: true,
+                vulnerable: false,
+              },
+              {
+                label: 'radiant (2d8)',
+                roll: 20,
+                resisted: false,
+                vulnerable: true,
+              },
+            ],
           },
           {
-            label: 'radiant (2d8)',
-            roll: 20,
-            resisted: false,
-            vulnerable: true,
+            roll: -4,
+            hit: false,
+            crit: false,
+            nat1: false,
+            damage: 0,
+          },
+        ],
+      },
+    ]);
+
+    await render(
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} />`,
+    );
+
+    assert
+      .dom('[data-test-attack-data-list="0"]')
+      .hasText(
+        'Number of attacks: 2\nTarget AC: 15\nAttack roll: 1d20 -3\n',
+        'the details for the attack should be displayed',
+      );
+
+    assert
+      .dom('[data-test-total-damage-header="0"]')
+      .isVisible('damage header should be displayed');
+
+    assert
+      .dom('[data-test-total-damage-header="0"]')
+      .hasText('*** Total Damage: 25 (1 hit) ***');
+
+    assert
+      .dom('[data-test-attack-detail-list="0"]')
+      .isVisible('attack details should be displayed');
+
+    assert.equal(
+      this.element.querySelector('[data-test-attack-detail-list="0"]')?.children
+        .length,
+      2,
+      '2 attacks should have been displayed',
+    );
+  });
+
+  test('it renders multiple repeated attacks correctly', async function (this: ElementContext, assert) {
+    this.set('repeatedAttackDetails', [
+      {
+        numberOfAttacks: 2,
+        targetAC: 15,
+        toHit: '-3',
+        damageList: [
+          new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name, true, false),
+          new Damage('2d8', DamageType.RADIANT.name, false, true),
+        ],
+        advantageState: AdvantageState.STRAIGHT,
+        totalDmg: 15,
+        totalNumberOfHits: 1,
+        attackDetailsList: [
+          {
+            roll: 18,
+            hit: true,
+            crit: false,
+            nat1: false,
+            damage: 15,
+            damageDetails: [
+              {
+                label: 'piercing (2d6 + 5 + 1d4)',
+                roll: 5,
+                resisted: true,
+                vulnerable: false,
+              },
+              {
+                label: 'radiant (2d8)',
+                roll: 10,
+                resisted: false,
+                vulnerable: false,
+              },
+            ],
+          },
+          {
+            roll: -4,
+            hit: false,
+            crit: false,
+            nat1: false,
+            damage: 0,
           },
         ],
       },
       {
-        roll: -4,
-        hit: false,
-        crit: false,
-        nat1: false,
-        damage: 0,
+        numberOfAttacks: 1,
+        targetAC: 14,
+        toHit: '3',
+        damageList: [new Damage('3d6', DamageType.ACID.name, true, true)],
+        advantageState: AdvantageState.ADVANTAGE,
+        totalDmg: 9,
+        totalNumberOfHits: 1,
+        attackDetailsList: [
+          {
+            roll: 15,
+            hit: true,
+            crit: false,
+            nat1: false,
+            damage: 9,
+            damageDetails: [
+              {
+                label: 'acid (3d6)',
+                roll: 9,
+                resisted: true,
+                vulnerable: true,
+              },
+            ],
+          },
+        ],
       },
-    ]);
-    this.set('damageList', [
-      new Damage('2d6 + 5', DamageType.ACID.name, true, true),
     ]);
 
     await render(
-      hbs`<DetailDisplay @numberOfAttacks={{2}} @targetAC={{15}} @toHit="3 - 1d6" @advantageState={{this.advantageState}} @damageList={{this.damageList}} @attackTriggered={{true}} @totalDmg={{25}} @numberOfHits={{1}} @attackDetailsList={{this.attackDetails}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} />`,
     );
 
+    // First attack
     assert
-      .dom('[data-test-plan-detail-list]')
+      .dom('[data-test-attack-data-list="0"]')
       .hasText(
-        'Target AC: 15\n' +
-          'Number of attacks: 2\n' +
-          'Attack roll: 1d20 + 3 - 1d6 (rolls with advantage)\n' +
-          'Attack damage: 2d6 + 5 acid damage (target resistant) (target vulnerable)',
-        'the details for the input damage should be displayed',
+        'Number of attacks: 2\nTarget AC: 15\nAttack roll: 1d20 -3\n',
+        'first attack: the details for the attack should be displayed',
       );
 
     assert
-      .dom('[data-test-total-damage-header]')
-      .isVisible('damage header should be displayed');
+      .dom('[data-test-total-damage-header="0"]')
+      .hasText('*** Total Damage: 15 (1 hit) ***');
+
+    const detailsList1 = this.element.querySelector(
+      '[data-test-attack-detail-list="0"]',
+    )?.children;
+    assert.true(detailsList1 != null, 'detail list should be present');
+    if (detailsList1) {
+      assert.equal(
+        detailsList1.length,
+        2,
+        'first attack: 2 attacks should have been displayed',
+      );
+
+      assert.equal(
+        detailsList1[0]?.className,
+        'li-hit',
+        'first attack: hit should have bullet point formatted as a hit',
+      );
+      assert.equal(
+        detailsList1[0]?.textContent?.trim().replace(/\s+/g, ' '),
+        'Attack roll: 18 piercing (2d6 + 5 + 1d4): 5 damage inflicted (resisted) radiant (2d8): 10 damage inflicted',
+        'first attack: hit should have expected detail text',
+      );
+
+      assert.equal(
+        detailsList1[1]?.className,
+        'li-miss',
+        'first attack: miss should have bullet point formatted as a miss',
+      );
+      assert.equal(
+        detailsList1[1]?.textContent?.trim().replace(/\s+/g, ' '),
+        'Attack roll: -4',
+        'first attack: miss should have expected detail text',
+      );
+    }
+
+    // Second attack
+    assert
+      .dom('[data-test-attack-data-list="1"]')
+      .hasText(
+        'Number of attacks: 1\nTarget AC: 14\nAttack roll: 1d20 + 3 (advantage)\n',
+        'second attack: the details for the attack should be displayed',
+      );
 
     assert
-      .dom('[data-test-total-damage-header]')
-      .hasText('*** Total Damage: 25 (1 hit) ***');
+      .dom('[data-test-total-damage-header="1"]')
+      .hasText('*** Total Damage: 9 (1 hit) ***');
 
-    assert
-      .dom('[data-test-attack-detail-list]')
-      .isVisible('attack details should be displayed');
+    const detailsList2 = this.element.querySelector(
+      '[data-test-attack-detail-list="1"]',
+    )?.children;
+    assert.true(detailsList2 != null, 'detail list should be present');
+    if (detailsList2) {
+      assert.equal(
+        detailsList2.length,
+        1,
+        'second attack: 1 attack should have been displayed',
+      );
+
+      assert.equal(
+        detailsList2[0]?.className,
+        'li-hit',
+        'second attack: hit should have bullet point formatted as a hit',
+      );
+      assert.equal(
+        detailsList2[0]?.textContent?.trim().replace(/\s+/g, ' '),
+        'Attack roll: 15 acid (3d6): 9 damage inflicted (resisted) (vulnerable)',
+        'second attack: hit should have expected detail text',
+      );
+    }
   });
 });


### PR DESCRIPTION
This adds a log of previous repeated attacks, as well as adjusting the format of displayed data to reduce redundant information (for instance, damage details are removed since they are usually easily visible in the attack log). The log automatically scrolls once it exceeds the size of the viewport.

The log is currently not stored anywhere, so is erased upon page refresh. Later work will save it to local or session storage and add an option for manually clearing the log.

![image](https://github.com/jbpeirce/multiattack-5e/assets/13395970/56a34d25-3c1e-43b2-8f14-6f785c6fad2f)
