### PR TITLE
Display doubled dice groups upon critical hits

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -32,7 +32,9 @@
           <ul data-test-damage-detail-list="{{index}}-{{index2}}">
             {{#each attackDetails.damageDetails as |damage|}}
             <li>
-              {{damage.roll}} {{damage.type}} damage ({{damage.dice}})
+              {{damage.roll}} {{damage.type}} damage
+              {{#if attackDetails.crit}} (<b>{{damage.dice}}</b>){{/if}}
+              {{#unless attackDetails.crit}} ({{damage.dice}}){{/unless}}
               {{#if damage.resisted}} (resisted){{/if}}
               {{#if damage.vulnerable}} (vulnerable){{/if}}
             </li>

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -77,7 +77,7 @@ export default class Attack {
         totalDmg += rolledDmg;
         damageDetails.push({
           type: `${damage.type}`,
-          dice: `${damage.damageString}`,
+          dice: `${damage.prettyString(crit)}`,
           roll: rolledDmg,
           resisted: damage.targetResistant,
           vulnerable: damage.targetVulnerable,

--- a/app/utils/damage.ts
+++ b/app/utils/damage.ts
@@ -93,4 +93,15 @@ export default class Damage {
 
     return total;
   }
+
+  /**
+   * Display this damage as a string. If the attack was a critical hit, double
+   * the number of dice displayed (eg "2d6 + 1d4 + 3" becomes "4d6 + 2d4 + 3").
+   * @param crit: whether this attack was a critical hit
+   * @returns a string representation of the damage inflicted by an attack
+   * described by this class
+   */
+  prettyString(crit: boolean): string {
+    return this.damage.prettyString(crit);
+  }
 }

--- a/app/utils/dice-group.ts
+++ b/app/utils/dice-group.ts
@@ -39,4 +39,17 @@ export default class DiceGroup {
   shouldAdd(): boolean {
     return this.add;
   }
+
+  /**
+   * Represent this dice group as a string, optionally doubling the number of
+   * dice printed.
+   *
+   * @param double whether to double the number of dice being displayed (eg
+   * "2d6" becomes "4d6")
+   * @return a string representation of this group of dice
+   */
+  prettyString(double: boolean): string {
+    const dice = double ? 2 * this.numDice : this.numDice;
+    return `${dice}d${this.die.sides}`;
+  }
 }

--- a/app/utils/dice-groups-and-modifier.ts
+++ b/app/utils/dice-groups-and-modifier.ts
@@ -33,4 +33,37 @@ export default class DiceGroupsAndModifier {
     total += this.modifier;
     return total;
   }
+
+  /**
+   * Represent this dice group as a string, optionally doubling the number of
+   * dice printed.
+   *
+   * @param double whether to double the number of dice being displayed (eg
+   * "2d6 + 2" becomes "4d6 + 2")
+   * @return a string representation of this dice group and modifier
+   */
+  prettyString(double: boolean): string {
+    let output = '';
+    let firstTerm = true;
+    for (const dice of this.diceGroups) {
+      // get the sign which goes before this dice group; skip the sign for the
+      // first term unless it's negative
+      let sign = dice.shouldAdd() ? ' + ' : ' - ';
+      if (firstTerm) {
+        sign = dice.shouldAdd() ? '' : '- ';
+      }
+
+      output = `${output}${sign}${dice.prettyString(double)}`;
+      firstTerm = false;
+    }
+
+    let sign = this.modifier >= 0 ? ' + ' : ' - ';
+    if (firstTerm) {
+      sign = this.modifier >= 0 ? '' : '- ';
+    }
+    if (this.modifier != 0) {
+      output = `${output}${sign}${Math.abs(this.modifier)}`;
+    }
+    return output;
+  }
 }

--- a/app/utils/repeated-attack.ts
+++ b/app/utils/repeated-attack.ts
@@ -70,7 +70,7 @@ export default class RepeatedAttack {
     return {
       numberOfAttacks: this.numberOfAttacks,
       targetAC: this.targetAC,
-      toHit: this.toHit,
+      toHit: attack.toHitModifier.prettyString(false),
       damageList: this.damageList,
       advantageState: this.advantageState,
 

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -65,7 +65,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       .hasText(
         'Number of attacks: 8\n' +
           'Target AC: 15\n' +
-          'Attack roll: 1d20 + 3 - 1D6 (disadvantage)\n',
+          'Attack roll: 1d20 - 1d6 + 3 (disadvantage)\n',
         'the details for the input damage should be displayed',
       );
 
@@ -140,7 +140,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       .hasText(
         'Number of attacks: 8\n' +
           'Target AC: 15\n' +
-          'Attack roll: 1d20 + 3 - 1D6 (disadvantage)\n',
+          'Attack roll: 1d20 - 1d6 + 3 (disadvantage)\n',
         'the details for the first set of attacks should be displayed',
       );
 

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -34,14 +34,14 @@ module('Integration | Component | detail-display', function (hooks) {
             damageDetails: [
               {
                 type: 'piercing',
-                dice: '2d6 + 5 + 1d4',
+                dice: '4d6 + 2d4 + 5',
                 roll: 11,
                 resisted: true,
                 vulnerable: false,
               },
               {
                 type: 'radiant',
-                dice: '2d8',
+                dice: '4d8',
                 roll: 26,
                 resisted: false,
                 vulnerable: true,
@@ -57,7 +57,7 @@ module('Integration | Component | detail-display', function (hooks) {
             damageDetails: [
               {
                 type: 'piercing',
-                dice: '2d6 + 5 + 1d4',
+                dice: '2d6 + 1d4 + 5',
                 roll: 5,
                 resisted: true,
                 vulnerable: false,
@@ -146,7 +146,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 25 (CRIT!) 11 piercing damage (2d6 + 5 + 1d4) (resisted) 26 radiant damage (2d8) (vulnerable)',
+        'Attack roll: 25 (CRIT!) 11 piercing damage (4d6 + 2d4 + 5) (resisted) 26 radiant damage (4d8) (vulnerable)',
         'critical hit should have expected detail text',
       );
 
@@ -157,7 +157,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 18 5 piercing damage (2d6 + 5 + 1d4) (resisted) 20 radiant damage (2d8) (vulnerable)',
+        'Attack roll: 18 5 piercing damage (2d6 + 1d4 + 5) (resisted) 20 radiant damage (2d8) (vulnerable)',
         'normal hit should have expected detail text',
       );
 
@@ -222,12 +222,12 @@ module('Integration | Component | detail-display', function (hooks) {
 
       assert.equal(
         critDamageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        '11 piercing damage (2d6 + 5 + 1d4) (resisted)',
+        '11 piercing damage (4d6 + 2d4 + 5) (resisted)',
         'piercing damage details should be displayed',
       );
       assert.equal(
         critDamageDetailsList[1]?.textContent?.trim().replace(/\s+/g, ' '),
-        '26 radiant damage (2d8) (vulnerable)',
+        '26 radiant damage (4d8) (vulnerable)',
         'radiant damage details should be displayed',
       );
     }
@@ -248,7 +248,7 @@ module('Integration | Component | detail-display', function (hooks) {
 
       assert.equal(
         regularDamageDetailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        '5 piercing damage (2d6 + 5 + 1d4) (resisted)',
+        '5 piercing damage (2d6 + 1d4 + 5) (resisted)',
         'piercing damage details should be displayed',
       );
       assert.equal(
@@ -282,7 +282,7 @@ module('Integration | Component | detail-display', function (hooks) {
             damageDetails: [
               {
                 type: 'piercing',
-                dice: '2d6 + 5 + 1d4',
+                dice: '2d6 + 1d4 + 5',
                 roll: 5,
                 resisted: true,
                 vulnerable: false,
@@ -361,7 +361,7 @@ module('Integration | Component | detail-display', function (hooks) {
             damageDetails: [
               {
                 type: 'piercing',
-                dice: '2d6 + 5 + 1d4',
+                dice: '2d6 + 1d4 + 5',
                 roll: 5,
                 resisted: true,
                 vulnerable: false,
@@ -447,7 +447,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList1[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 18 5 piercing damage (2d6 + 5 + 1d4) (resisted) 10 radiant damage (2d8)',
+        'Attack roll: 18 5 piercing damage (2d6 + 1d4 + 5) (resisted) 10 radiant damage (2d8)',
         'first attack: hit should have expected detail text',
       );
 

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -241,7 +241,7 @@ module('Unit | Utils | attack', function (hooks) {
     const expectedDmg: DamageDetails[] = [
       {
         type: 'piercing',
-        dice: '2d6 + 5 + 1d4',
+        dice: '2d6 + 1d4 + 5',
         roll: 13,
         resisted: false,
         vulnerable: false,
@@ -309,14 +309,14 @@ module('Unit | Utils | attack', function (hooks) {
     const expectedDmg: DamageDetails[] = [
       {
         type: 'piercing',
-        dice: '2d6 + 5 + 1d4',
+        dice: '4d6 + 2d4 + 5',
         roll: 25,
         resisted: false,
         vulnerable: false,
       },
       {
         type: 'radiant',
-        dice: '2d8',
+        dice: '4d8',
         roll: 14,
         resisted: false,
         vulnerable: false,

--- a/tests/unit/utils/dice-group-test.ts
+++ b/tests/unit/utils/dice-group-test.ts
@@ -79,4 +79,27 @@ module('Unit | Utils | dice-group', function (hooks) {
       'roll of multiple dice should return expected sum',
     );
   });
+
+  test('it prints as expected', async function (assert) {
+    assert.equal(
+      new DiceGroup(1, 6).prettyString(false),
+      '1d6',
+      'group being added should print as expected',
+    );
+    assert.equal(
+      new DiceGroup(3, 12, false).prettyString(false),
+      '3d12',
+      'whether a group is being subtracted should not affect its printing',
+    );
+    assert.equal(
+      new DiceGroup(2, 10, false).prettyString(true),
+      '4d10',
+      'the number of dice should be doubled when requested',
+    );
+    assert.equal(
+      new DiceGroup(0, 4, false).prettyString(true),
+      '0d4',
+      'zero dice should be handled without errors',
+    );
+  });
 });

--- a/tests/unit/utils/dice-groups-and-modifier-test.ts
+++ b/tests/unit/utils/dice-groups-and-modifier-test.ts
@@ -117,4 +117,58 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       'roll should inflict 22 + (5 + 1 + 2) + (2 + 2) = 34 total damage',
     );
   });
+
+  test('it prints as expected', async function (assert) {
+    assert.equal(
+      new DiceGroupsAndModifier(
+        [new DiceGroup(3, 8), new DiceGroup(2, 12)],
+        2,
+      ).prettyString(false),
+      '3d8 + 2d12 + 2',
+      'groups and modifiers being added should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier(
+        [new DiceGroup(3, 8), new DiceGroup(2, 4, false)],
+        -5,
+      ).prettyString(false),
+      '3d8 - 2d4 - 5',
+      'groups and modifiers being subtracted should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier([], 12).prettyString(false),
+      '12',
+      'solitary positive modifier should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier([], -5).prettyString(false),
+      '- 5',
+      'solitary negative modifier should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier([new DiceGroup(1, 4)], 0).prettyString(false),
+      '1d4',
+      'single dice group should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier([new DiceGroup(1, 4, false)], 0).prettyString(
+        false,
+      ),
+      '- 1d4',
+      'single negative dice group should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier(
+        [new DiceGroup(3, 8), new DiceGroup(2, 4, false)],
+        -5,
+      ).prettyString(true),
+      '6d8 - 4d4 - 5',
+      'doubled dice should print as expected',
+    );
+    assert.equal(
+      new DiceGroupsAndModifier([], 12).prettyString(true),
+      '12',
+      'solitary positive modifier should not be affected by doubled-dice parameter',
+    );
+  });
 });


### PR DESCRIPTION
This changes the attack display so that when a critical hit is rolled, the damage dice are printed with double the usual number of dice. This reflects that when a critical hit is rolled, twice the number of dice are rolled (although the modifier is not doubled). For instance, "2d6 + 4" damage prints as "4d6 + 4" on a critical hit.

This also standardizes the printing for damage dice and to-hit modifiers so that there are spaces between the terms and the dice groups are printed before the modifier. This is potentially slightly confusing, since it does not exactly match the text entered into the form; however, it simplifies doubling the dice groups and makes the display more consistent.