### PR TITLE
Fix display of dice groups and modifiers when a 0 modifier is alone

### DIFF
--- a/app/utils/dice-groups-and-modifier.ts
+++ b/app/utils/dice-groups-and-modifier.ts
@@ -61,7 +61,8 @@ export default class DiceGroupsAndModifier {
     if (firstTerm) {
       sign = this.modifier >= 0 ? '' : '- ';
     }
-    if (this.modifier != 0) {
+    // Skip 0 modifiers unless they are the only term present
+    if (firstTerm || this.modifier != 0) {
       output = `${output}${sign}${Math.abs(this.modifier)}`;
     }
     return output;

--- a/tests/unit/utils/dice-groups-and-modifier-test.ts
+++ b/tests/unit/utils/dice-groups-and-modifier-test.ts
@@ -146,6 +146,11 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       'solitary negative modifier should print as expected',
     );
     assert.equal(
+      new DiceGroupsAndModifier([], 0).prettyString(false),
+      '0',
+      '0 modifier should print if there are no accompanying dice groups',
+    );
+    assert.equal(
       new DiceGroupsAndModifier([new DiceGroup(1, 4)], 0).prettyString(false),
       '1d4',
       'single dice group should print as expected',


### PR DESCRIPTION
If the constant modifier on a dice term is 0, but a dice group is present, the 0 should be omitted (eg "1d4" not "1d4 + 0"). However, if the 0 is the only term present, it should be printed ("1d20 + 0" not "1d20" and "0" rather than "" for damage strings).