### PR TITLE
Adjust wording of introductory paragraph

### DIFF
--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -1,14 +1,14 @@
 <div class="row align-items-center">
   <div class="col col-lg-9 pt-5 pb-4">
-    <h1>Horde Damage Calculator</h1>
+    <h1>Repeated Attack Simulator</h1>
     <p>
-      Want to simulate multiple attacks on a single target without rolling every die? Enter the attack details, the
-      number of attacks, and the AC of the target, and the tool will calculate the damage to the target and display the
-      total damage alongside a breakdown of each attack.
+      Has a horde of zombies cornered a victim? Is a marilith focusing its attacks on a single opponent? This tool
+      simulates repeated identical attacks on a single target and displays the total damage alongside a breakdown of
+      the attacks.
     </p>
     <p>
       This uses a 20-sided die for attack rolls, as in D&D 5e and similar systems. If an attack is a critical hit (rolls
-      a 20), the damage dice are rolled twice. Rolling a 1 always misses.
+      a 20), the damage dice are rolled twice. Rolling a 1 on the d20 always misses, and a 20 always hits.
     </p>
   </div>
 </div>


### PR DESCRIPTION
The form's labels should make it fairly clear what information to enter, so it does not need to be re-stated in the introductory text. This adds some examples of when this tool might be useful.