### PR TITLE
Display dice rolls in hovertext

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -36,13 +36,15 @@
 
         {{#if attackDetails.hit }}
         <li class="li-hit">
-          Attack roll: {{attackDetails.roll}}
+          Attack roll: <span data-test-attack-roll-detail="{{index}}-{{index2}}"
+            title="{{this.getRollDetailString attackDetails.roll.rolls}}">{{attackDetails.roll.total}}</span>
           {{#if attackDetails.crit}} (CRIT!){{/if}}
 
           <ul data-test-damage-detail-list="{{index}}-{{index2}}">
             {{#each attackDetails.damageDetails as |damage index3|}}
             <li>
-              <span data-test-damage-roll-detail="{{index}}-{{index2}}-{{index3}}" title="{{this.getRollDetailString damage.roll.rolls}}">{{damage.roll.total}}</span>
+              <span data-test-damage-roll-detail="{{index}}-{{index2}}-{{index3}}"
+                title="{{this.getRollDetailString damage.roll.rolls}}">{{damage.roll.total}}</span>
               {{damage.type}} damage
               {{#if attackDetails.crit}} (<b>{{damage.dice}}</b>){{/if}}
               {{#unless attackDetails.crit}} ({{damage.dice}}){{/unless}}
@@ -56,7 +58,8 @@
 
         {{#unless attackDetails.hit }}
         <li class="li-miss">
-          Attack roll: {{attackDetails.roll}}
+          Attack roll: <span data-test-attack-roll-detail="{{index}}-{{index2}}"
+            title="{{this.getRollDetailString attackDetails.roll.rolls}}">{{attackDetails.roll.total}}</span>
           {{#if attackDetails.nat1}} (NAT 1!){{/if}}
         </li>
         {{/unless}}

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -5,7 +5,8 @@
     </h2>
   </div>
   <div class="col col-sm-4 d-flex justify-content-end">
-    <button class="btn btn-danger btn-sm" type="button" {{on "click" @clearAttackLog}} data-test-button-clear-attack-log>
+    <button class="btn btn-danger btn-sm" type="button" {{on "click" @clearAttackLog}}
+      data-test-button-clear-attack-log>
       Clear
     </button>
   </div>
@@ -39,9 +40,10 @@
           {{#if attackDetails.crit}} (CRIT!){{/if}}
 
           <ul data-test-damage-detail-list="{{index}}-{{index2}}">
-            {{#each attackDetails.damageDetails as |damage|}}
+            {{#each attackDetails.damageDetails as |damage index3|}}
             <li>
-              {{damage.roll.total}} {{damage.type}} damage
+              <span data-test-damage-roll-detail="{{index}}-{{index2}}-{{index3}}" title="{{this.getRollDetailString damage.roll.rolls}}">{{damage.roll.total}}</span>
+              {{damage.type}} damage
               {{#if attackDetails.crit}} (<b>{{damage.dice}}</b>){{/if}}
               {{#unless attackDetails.crit}} ({{damage.dice}}){{/unless}}
               {{#if damage.resisted}} (resisted){{/if}}

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -41,7 +41,7 @@
           <ul data-test-damage-detail-list="{{index}}-{{index2}}">
             {{#each attackDetails.damageDetails as |damage|}}
             <li>
-              {{damage.roll}} {{damage.type}} damage
+              {{damage.roll.total}} {{damage.type}} damage
               {{#if attackDetails.crit}} (<b>{{damage.dice}}</b>){{/if}}
               {{#unless attackDetails.crit}} ({{damage.dice}}){{/unless}}
               {{#if damage.resisted}} (resisted){{/if}}

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 
+import type { NameAndRolls } from 'multiattack-5e/utils/dice-groups-and-modifier';
+
 import AdvantageState from './advantage-state-enum';
 
 export default class DetailDisplayComponent extends Component {
@@ -35,5 +37,9 @@ export default class DetailDisplayComponent extends Component {
     } else {
       return 'hits';
     }
+  };
+
+  getRollDetailString = (rollDetails: NameAndRolls[]) => {
+    return rollDetails.map((roll) => `${roll.name}: ${roll.rolls}`).join(' | ');
   };
 }

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -40,6 +40,8 @@ export default class DetailDisplayComponent extends Component {
   };
 
   getRollDetailString = (rollDetails: NameAndRolls[]) => {
-    return rollDetails.map((roll) => `${roll.name}: ${roll.rolls}`).join(' | ');
+    return rollDetails
+      .map((roll) => `${roll.name}: ${roll.rolls.join(', ')}`)
+      .join(' | ');
   };
 }

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -39,6 +39,13 @@ export default class DetailDisplayComponent extends Component {
     }
   };
 
+  /**
+   * Get a string displaying the given set of roll details.
+   * @param rollDetails information about the rolls from one or more groups of
+   * dice
+   * @returns a string pairing the name of each group of dice with the
+   * associated rolls
+   */
   getRollDetailString = (rollDetails: NameAndRolls[]) => {
     return rollDetails
       .map((roll) => `${roll.name}: ${roll.rolls.join(', ')}`)

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -58,7 +58,7 @@ export default class Attack {
     // roll any dice groups which modify the attack (such as a 1d4 from Bless or
     // -1d6 from Synaptic Static) and apply the fixed modifiers.
     const attackD20 = this.getD20Roll(advantage, disadvantage);
-    const attackRoll = attackD20 + this.toHitModifier.rollAndGetTotal(false);
+    const attackRoll = attackD20 + this.toHitModifier.roll(false).total;
 
     const crit = attackD20 == 20;
     const nat1 = attackD20 == 1;

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -74,11 +74,11 @@ export default class Attack {
       numberOfHits += 1;
       for (const damage of this.damageTypes) {
         const rolledDmg = damage.roll(crit);
-        totalDmg += rolledDmg;
+        totalDmg += rolledDmg.total;
         damageDetails.push({
           type: `${damage.type}`,
           dice: `${damage.prettyString(crit)}`,
-          roll: rolledDmg,
+          roll: rolledDmg.total,
           resisted: damage.targetResistant,
           vulnerable: damage.targetVulnerable,
         });

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -1,5 +1,7 @@
 import Damage from './damage';
-import DiceGroupsAndModifier from './dice-groups-and-modifier';
+import DiceGroupsAndModifier, {
+  type GroupRollDetails,
+} from './dice-groups-and-modifier';
 import DiceStringParser from './dice-string-parser';
 import Die from './die';
 
@@ -16,7 +18,7 @@ export interface AttackDetails {
 export interface DamageDetails {
   type: string;
   dice: string;
-  roll: number;
+  roll: GroupRollDetails;
   resisted: boolean;
   vulnerable: boolean;
 }
@@ -78,7 +80,7 @@ export default class Attack {
         damageDetails.push({
           type: `${damage.type}`,
           dice: `${damage.prettyString(crit)}`,
-          roll: rolledDmg.total,
+          roll: rolledDmg,
           resisted: damage.targetResistant,
           vulnerable: damage.targetVulnerable,
         });

--- a/app/utils/damage.ts
+++ b/app/utils/damage.ts
@@ -108,7 +108,7 @@ export default class Damage {
       throw new Error('Damage did not have all necessary fields set');
     }
 
-    let total = this.damage.rollAndGetTotal(crit);
+    let total = this.damage.roll(crit).total;
 
     // Reset the total to 0 if it is negative (which may happen due to a
     // negative damage modifier)

--- a/app/utils/dice-group.ts
+++ b/app/utils/dice-group.ts
@@ -1,5 +1,10 @@
 import Die from 'multiattack-5e/utils/die';
 
+export interface RollDetails {
+  total: number;
+  rolls: number[];
+}
+
 export default class DiceGroup {
   numDice: number;
   die: Die;
@@ -21,12 +26,18 @@ export default class DiceGroup {
    *
    * @returns the total from rolling all of the dice in this group
    */
-  roll(): number {
-    let total = 0;
+  roll(): RollDetails {
+    const details: RollDetails = {
+      total: 0,
+      rolls: [],
+    };
+
     for (let i = 0; i < this.numDice; i++) {
-      total += this.die.roll();
+      const roll = this.die.roll();
+      details.total += roll;
+      details.rolls.push(roll);
     }
-    return total;
+    return details;
   }
 
   /**

--- a/app/utils/dice-groups-and-modifier.ts
+++ b/app/utils/dice-groups-and-modifier.ts
@@ -27,9 +27,9 @@ export default class DiceGroupsAndModifier {
    * modifier once). This is valuable for calculating the damage from a critical
    * hit.
    * @returns the total value from rolling the dice groups described by this
-   * class and adding the given modifier to them
+   * class and adding the given modifier to them, alongside details of each roll.
    */
-  rollAndGetTotal(doubleDice: boolean): number {
+  roll(doubleDice: boolean): GroupRollDetails {
     const details: GroupRollDetails = {
       total: 0,
       rolls: [],
@@ -58,7 +58,7 @@ export default class DiceGroupsAndModifier {
     // Once all dice are rolled, add the modifier to the total
     details.total += this.modifier;
 
-    return details.total;
+    return details;
   }
 
   /**

--- a/app/utils/dice-groups-and-modifier.ts
+++ b/app/utils/dice-groups-and-modifier.ts
@@ -36,31 +36,29 @@ export default class DiceGroupsAndModifier {
     };
 
     for (const dice of this.diceGroups) {
-      this.rollAndUpdateDetails(dice, doubleDice, details);
+      const rolls = [];
+      const sign = dice.shouldAdd() ? 1 : -1;
 
-      if (doubleDice) {
-        this.rollAndUpdateDetails(dice, doubleDice, details);
+      // Roll the dice once or twice, as instructed
+      const repetitions = doubleDice ? 2 : 1;
+      for (let i = 0; i < repetitions; i++) {
+        const roll = dice.roll();
+        details.total += sign * roll.total;
+        rolls.push(...roll.rolls);
       }
+
+      const signString = dice.shouldAdd() ? '' : '-';
+      const diceName = `${signString}${dice.prettyString(doubleDice)}`;
+      details.rolls.push({
+        name: diceName,
+        rolls: rolls,
+      });
     }
 
+    // Once all dice are rolled, add the modifier to the total
+    details.total += this.modifier;
+
     return details.total;
-  }
-
-  rollAndUpdateDetails(
-    dice: DiceGroup,
-    doubleDice: boolean,
-    details: GroupRollDetails,
-  ) {
-    const sign = dice.shouldAdd() ? 1 : -1;
-    const roll = dice.roll();
-    details.total += sign * roll.total;
-
-    const signString = dice.shouldAdd() ? '' : '-';
-    const diceName = `${signString}${dice.prettyString(doubleDice)}`;
-    details.rolls.push({
-      name: diceName,
-      rolls: roll.rolls,
-    });
   }
 
   /**

--- a/app/utils/dice-groups-and-modifier.ts
+++ b/app/utils/dice-groups-and-modifier.ts
@@ -1,5 +1,15 @@
 import DiceGroup from './dice-group';
 
+export interface GroupRollDetails {
+  total: number;
+  rolls: NameAndRolls[];
+}
+
+export interface NameAndRolls {
+  name: string;
+  rolls: number[];
+}
+
 export default class DiceGroupsAndModifier {
   diceGroups: DiceGroup[];
   modifier: number;
@@ -20,18 +30,37 @@ export default class DiceGroupsAndModifier {
    * class and adding the given modifier to them
    */
   rollAndGetTotal(doubleDice: boolean): number {
-    let total = 0;
+    const details: GroupRollDetails = {
+      total: 0,
+      rolls: [],
+    };
+
     for (const dice of this.diceGroups) {
-      const sign = dice.shouldAdd() ? 1 : -1;
-      total += sign * dice.roll();
+      this.rollAndUpdateDetails(dice, doubleDice, details);
 
       if (doubleDice) {
-        total += sign * dice.roll();
+        this.rollAndUpdateDetails(dice, doubleDice, details);
       }
     }
 
-    total += this.modifier;
-    return total;
+    return details.total;
+  }
+
+  rollAndUpdateDetails(
+    dice: DiceGroup,
+    doubleDice: boolean,
+    details: GroupRollDetails,
+  ) {
+    const sign = dice.shouldAdd() ? 1 : -1;
+    const roll = dice.roll();
+    details.total += sign * roll.total;
+
+    const signString = dice.shouldAdd() ? '' : '-';
+    const diceName = `${signString}${dice.prettyString(doubleDice)}`;
+    details.rolls.push({
+      name: diceName,
+      rolls: roll.rolls,
+    });
   }
 
   /**

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -223,7 +223,7 @@ module('Integration | Component | detail-display', function (hooks) {
     });
 
     await render(
-      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}}  @clearAttackLog={{this.doNotCall}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} @clearAttackLog={{this.doNotCall}} />`,
     );
 
     assert
@@ -506,7 +506,7 @@ module('Integration | Component | detail-display', function (hooks) {
     });
 
     await render(
-      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}}  @clearAttackLog={{this.doNotCall}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} @clearAttackLog={{this.doNotCall}} />`,
     );
 
     assert
@@ -671,7 +671,7 @@ module('Integration | Component | detail-display', function (hooks) {
     });
 
     await render(
-      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}}  @clearAttackLog={{this.doNotCall}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} @clearAttackLog={{this.doNotCall}} />`,
     );
 
     // First attack

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -35,14 +35,34 @@ module('Integration | Component | detail-display', function (hooks) {
               {
                 type: 'piercing',
                 dice: '4d6 + 2d4 + 5',
-                roll: 11,
+                roll: {
+                  total: 11,
+                  rolls: [
+                    {
+                      name: '4d6',
+                      rolls: [4, 5, 2, 2],
+                    },
+                    {
+                      name: '2d4',
+                      rolls: [3, 2],
+                    },
+                  ],
+                },
                 resisted: true,
                 vulnerable: false,
               },
               {
                 type: 'radiant',
                 dice: '4d8',
-                roll: 26,
+                roll: {
+                  total: 26,
+                  rolls: [
+                    {
+                      name: '4d8',
+                      rolls: [2, 7, 1, 3],
+                    },
+                  ],
+                },
                 resisted: false,
                 vulnerable: true,
               },
@@ -58,14 +78,34 @@ module('Integration | Component | detail-display', function (hooks) {
               {
                 type: 'piercing',
                 dice: '2d6 + 1d4 + 5',
-                roll: 5,
+                roll: {
+                  total: 5,
+                  rolls: [
+                    {
+                      name: '2d6',
+                      rolls: [2, 1],
+                    },
+                    {
+                      name: '1d4',
+                      rolls: [2],
+                    },
+                  ],
+                },
                 resisted: true,
                 vulnerable: false,
               },
               {
                 type: 'radiant',
                 dice: '2d8',
-                roll: 20,
+                roll: {
+                  total: 20,
+                  rolls: [
+                    {
+                      name: '2d8',
+                      rolls: [3, 7],
+                    },
+                  ],
+                },
                 resisted: false,
                 vulnerable: true,
               },
@@ -111,15 +151,15 @@ module('Integration | Component | detail-display', function (hooks) {
     });
 
     await render(
-      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} @clearAttackLog={{this.doNotCall}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}}  @clearAttackLog={{this.doNotCall}} />`,
     );
 
     assert
       .dom('[data-test-attack-data-list="0"]')
       .hasText(
         'Number of attacks: 8\n' +
-          'Target AC: 15\n' +
-          'Attack roll: 1d20 + 3 - 1d6 (disadvantage)\n',
+        'Target AC: 15\n' +
+        'Attack roll: 1d20 + 3 - 1d6 (disadvantage)\n',
         'the details for the input damage should be displayed',
       );
 
@@ -290,14 +330,34 @@ module('Integration | Component | detail-display', function (hooks) {
               {
                 type: 'piercing',
                 dice: '2d6 + 1d4 + 5',
-                roll: 5,
+                roll: {
+                  total: 5,
+                  rolls: [
+                    {
+                      name: '2d6',
+                      rolls: [2, 1],
+                    },
+                    {
+                      name: '1d4',
+                      rolls: [2],
+                    },
+                  ],
+                },
                 resisted: true,
                 vulnerable: false,
               },
               {
                 type: 'radiant',
                 dice: '2d8',
-                roll: 20,
+                roll: {
+                  total: 20,
+                  rolls: [
+                    {
+                      name: '2d8',
+                      rolls: [2, 8],
+                    },
+                  ],
+                },
                 resisted: false,
                 vulnerable: true,
               },
@@ -322,7 +382,7 @@ module('Integration | Component | detail-display', function (hooks) {
     });
 
     await render(
-      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} @clearAttackLog={{this.doNotCall}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}}  @clearAttackLog={{this.doNotCall}} />`,
     );
 
     assert
@@ -376,14 +436,34 @@ module('Integration | Component | detail-display', function (hooks) {
               {
                 type: 'piercing',
                 dice: '2d6 + 1d4 + 5',
-                roll: 5,
+                roll: {
+                  total: 5,
+                  rolls: [
+                    {
+                      name: '2d6',
+                      rolls: [2, 1],
+                    },
+                    {
+                      name: '1d4',
+                      rolls: [2],
+                    },
+                  ],
+                },
                 resisted: true,
                 vulnerable: false,
               },
               {
                 type: 'radiant',
                 dice: '2d8',
-                roll: 10,
+                roll: {
+                  total: 10,
+                  rolls: [
+                    {
+                      name: '2d8',
+                      rolls: [2, 8],
+                    },
+                  ],
+                },
                 resisted: false,
                 vulnerable: false,
               },
@@ -404,7 +484,7 @@ module('Integration | Component | detail-display', function (hooks) {
         toHit: '3',
         damageList: [new Damage('3d6', DamageType.ACID.name, true, true)],
         advantageState: AdvantageState.ADVANTAGE,
-        totalDmg: 9,
+        totalDmg: 10,
         totalNumberOfHits: 1,
         attackDetailsList: [
           {
@@ -412,12 +492,20 @@ module('Integration | Component | detail-display', function (hooks) {
             hit: true,
             crit: false,
             nat1: false,
-            damage: 9,
+            damage: 10,
             damageDetails: [
               {
                 type: 'acid',
                 dice: '3d6',
-                roll: 9,
+                roll: {
+                  total: 10,
+                  rolls: [
+                    {
+                      name: '3d6',
+                      rolls: [2, 5, 4],
+                    },
+                  ],
+                },
                 resisted: true,
                 vulnerable: true,
               },
@@ -435,7 +523,7 @@ module('Integration | Component | detail-display', function (hooks) {
     });
 
     await render(
-      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}} @clearAttackLog={{this.doNotCall}} />`,
+      hbs`<DetailDisplay @repeatedAttackLog={{this.repeatedAttackDetails}}  @clearAttackLog={{this.doNotCall}} />`,
     );
 
     // First attack
@@ -494,7 +582,7 @@ module('Integration | Component | detail-display', function (hooks) {
 
     assert
       .dom('[data-test-total-damage-header="1"]')
-      .hasText('Total Damage: 9 (1 hit)');
+      .hasText('Total Damage: 10 (1 hit)');
 
     const detailsList2 = this.element.querySelector(
       '[data-test-attack-detail-list="1"]',
@@ -514,7 +602,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList2[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 15 9 acid damage (3d6) (resisted) (vulnerable)',
+        'Attack roll: 15 10 acid damage (3d6) (resisted) (vulnerable)',
         'second attack: hit should have expected detail text',
       );
     }

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -158,8 +158,8 @@ module('Integration | Component | detail-display', function (hooks) {
       .dom('[data-test-attack-data-list="0"]')
       .hasText(
         'Number of attacks: 8\n' +
-        'Target AC: 15\n' +
-        'Attack roll: 1d20 + 3 - 1d6 (disadvantage)\n',
+          'Target AC: 15\n' +
+          'Attack roll: 1d20 + 3 - 1d6 (disadvantage)\n',
         'the details for the input damage should be displayed',
       );
 
@@ -253,6 +253,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
     }
 
+    // Inspect the detailed display of the critical hit
     const critDamageDetailsList = this.element.querySelector(
       '[data-test-damage-detail-list="0-0"]',
     )?.children;
@@ -279,6 +280,15 @@ module('Integration | Component | detail-display', function (hooks) {
       );
     }
 
+    assert
+      .dom('[data-test-damage-roll-detail="0-0-0"]')
+      .hasAttribute('title', '4d6: 4,5,2,2 | 2d4: 3,2');
+
+    assert
+      .dom('[data-test-damage-roll-detail="0-0-1"]')
+      .hasAttribute('title', '4d8: 2,7,1,3');
+
+    // Inspect the detailed display of the regular hit
     const regularDamageDetailsList = this.element.querySelector(
       '[data-test-damage-detail-list="0-1"]',
     )?.children;
@@ -304,6 +314,14 @@ module('Integration | Component | detail-display', function (hooks) {
         'radiant damage details should be displayed',
       );
     }
+
+    assert
+      .dom('[data-test-damage-roll-detail="0-1-0"]')
+      .hasAttribute('title', '2d6: 2,1 | 1d4: 2');
+
+    assert
+      .dom('[data-test-damage-roll-detail="0-1-1"]')
+      .hasAttribute('title', '2d8: 3,7');
   });
 
   test('it renders a single hit correctly', async function (this: ElementContext, assert) {

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -282,11 +282,11 @@ module('Integration | Component | detail-display', function (hooks) {
 
     assert
       .dom('[data-test-damage-roll-detail="0-0-0"]')
-      .hasAttribute('title', '4d6: 4,5,2,2 | 2d4: 3,2');
+      .hasAttribute('title', '4d6: 4, 5, 2, 2 | 2d4: 3, 2');
 
     assert
       .dom('[data-test-damage-roll-detail="0-0-1"]')
-      .hasAttribute('title', '4d8: 2,7,1,3');
+      .hasAttribute('title', '4d8: 2, 7, 1, 3');
 
     // Inspect the detailed display of the regular hit
     const regularDamageDetailsList = this.element.querySelector(
@@ -317,11 +317,11 @@ module('Integration | Component | detail-display', function (hooks) {
 
     assert
       .dom('[data-test-damage-roll-detail="0-1-0"]')
-      .hasAttribute('title', '2d6: 2,1 | 1d4: 2');
+      .hasAttribute('title', '2d6: 2, 1 | 1d4: 2');
 
     assert
       .dom('[data-test-damage-roll-detail="0-1-1"]')
-      .hasAttribute('title', '2d8: 3,7');
+      .hasAttribute('title', '2d8: 3, 7');
   });
 
   test('it renders a single hit correctly', async function (this: ElementContext, assert) {

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -26,7 +26,19 @@ module('Integration | Component | detail-display', function (hooks) {
         totalNumberOfHits: 2,
         attackDetailsList: [
           {
-            roll: 25,
+            roll: {
+              total: 21,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [20],
+                },
+                {
+                  name: '-1d6',
+                  rolls: [2],
+                },
+              ],
+            },
             hit: true,
             crit: true,
             nat1: false,
@@ -69,7 +81,19 @@ module('Integration | Component | detail-display', function (hooks) {
             ],
           },
           {
-            roll: 18,
+            roll: {
+              total: 18,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [18],
+                },
+                {
+                  name: '-1d6',
+                  rolls: [3],
+                },
+              ],
+            },
             hit: true,
             crit: false,
             nat1: false,
@@ -112,28 +136,76 @@ module('Integration | Component | detail-display', function (hooks) {
             ],
           },
           {
-            roll: -4,
+            roll: {
+              total: -1,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [2],
+                },
+                {
+                  name: '-1d6',
+                  rolls: [6],
+                },
+              ],
+            },
             hit: false,
             crit: false,
             nat1: false,
             damage: 0,
           },
           {
-            roll: 13,
+            roll: {
+              total: 13,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [14],
+                },
+                {
+                  name: '-1d6',
+                  rolls: [4],
+                },
+              ],
+            },
             hit: false,
             crit: false,
             nat1: false,
             damage: 0,
           },
           {
-            roll: -5,
+            roll: {
+              total: -2,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [1],
+                },
+                {
+                  name: '-1d6',
+                  rolls: [6],
+                },
+              ],
+            },
             hit: false,
             crit: false,
             nat1: true,
             damage: 0,
           },
           {
-            roll: 6,
+            roll: {
+              total: 6,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [8],
+                },
+                {
+                  name: '-1d6',
+                  rolls: [5],
+                },
+              ],
+            },
             hit: false,
             crit: false,
             nat1: false,
@@ -193,9 +265,12 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 25 (CRIT!) 11 piercing damage (4d6 + 2d4 + 5) (resisted) 26 radiant damage (4d8) (vulnerable)',
+        'Attack roll: 21 (CRIT!) 11 piercing damage (4d6 + 2d4 + 5) (resisted) 26 radiant damage (4d8) (vulnerable)',
         'critical hit should have expected detail text',
       );
+      assert
+        .dom('[data-test-attack-roll-detail="0-0"]')
+        .hasAttribute('title', '1d20: 20 | -1d6: 2');
 
       assert.equal(
         detailsList[1]?.className,
@@ -207,6 +282,9 @@ module('Integration | Component | detail-display', function (hooks) {
         'Attack roll: 18 5 piercing damage (2d6 + 1d4 + 5) (resisted) 20 radiant damage (2d8) (vulnerable)',
         'normal hit should have expected detail text',
       );
+      assert
+        .dom('[data-test-attack-roll-detail="0-1"]')
+        .hasAttribute('title', '1d20: 18 | -1d6: 3');
 
       assert.equal(
         detailsList[2]?.className,
@@ -215,9 +293,12 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList[2]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: -4',
+        'Attack roll: -1',
         'negative attack roll should have expected detail text',
       );
+      assert
+        .dom('[data-test-attack-roll-detail="0-2"]')
+        .hasAttribute('title', '1d20: 2 | -1d6: 6');
 
       assert.equal(
         detailsList[3]?.className,
@@ -229,6 +310,9 @@ module('Integration | Component | detail-display', function (hooks) {
         'Attack roll: 13',
         'double-digit attack roll with a miss should have expected detail text',
       );
+      assert
+        .dom('[data-test-attack-roll-detail="0-3"]')
+        .hasAttribute('title', '1d20: 14 | -1d6: 4');
 
       assert.equal(
         detailsList[4]?.className,
@@ -237,9 +321,12 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList[4]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: -5 (NAT 1!)',
+        'Attack roll: -2 (NAT 1!)',
         'natural one should have expected detail text',
       );
+      assert
+        .dom('[data-test-attack-roll-detail="0-4"]')
+        .hasAttribute('title', '1d20: 1 | -1d6: 6');
 
       assert.equal(
         detailsList[5]?.className,
@@ -251,6 +338,9 @@ module('Integration | Component | detail-display', function (hooks) {
         'Attack roll: 6',
         'single-digit attack roll with a miss should have expected detail text',
       );
+      assert
+        .dom('[data-test-attack-roll-detail="0-5"]')
+        .hasAttribute('title', '1d20: 8 | -1d6: 5');
     }
 
     // Inspect the detailed display of the critical hit
@@ -339,7 +429,15 @@ module('Integration | Component | detail-display', function (hooks) {
         totalNumberOfHits: 1,
         attackDetailsList: [
           {
-            roll: 18,
+            roll: {
+              total: 16,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [19],
+                },
+              ],
+            },
             hit: true,
             crit: false,
             nat1: false,
@@ -382,7 +480,15 @@ module('Integration | Component | detail-display', function (hooks) {
             ],
           },
           {
-            roll: -4,
+            roll: {
+              total: -1,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [2],
+                },
+              ],
+            },
             hit: false,
             crit: false,
             nat1: false,
@@ -445,7 +551,15 @@ module('Integration | Component | detail-display', function (hooks) {
         totalNumberOfHits: 1,
         attackDetailsList: [
           {
-            roll: 18,
+            roll: {
+              total: 16,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [19],
+                },
+              ],
+            },
             hit: true,
             crit: false,
             nat1: false,
@@ -488,7 +602,15 @@ module('Integration | Component | detail-display', function (hooks) {
             ],
           },
           {
-            roll: -4,
+            roll: {
+              total: -1,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [2],
+                },
+              ],
+            },
             hit: false,
             crit: false,
             nat1: false,
@@ -506,7 +628,15 @@ module('Integration | Component | detail-display', function (hooks) {
         totalNumberOfHits: 1,
         attackDetailsList: [
           {
-            roll: 15,
+            roll: {
+              total: 15,
+              rolls: [
+                {
+                  name: '1d20',
+                  rolls: [18],
+                },
+              ],
+            },
             hit: true,
             crit: false,
             nat1: false,
@@ -574,7 +704,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList1[0]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: 18 5 piercing damage (2d6 + 1d4 + 5) (resisted) 10 radiant damage (2d8)',
+        'Attack roll: 16 5 piercing damage (2d6 + 1d4 + 5) (resisted) 10 radiant damage (2d8)',
         'first attack: hit should have expected detail text',
       );
 
@@ -585,7 +715,7 @@ module('Integration | Component | detail-display', function (hooks) {
       );
       assert.equal(
         detailsList1[1]?.textContent?.trim().replace(/\s+/g, ' '),
-        'Attack roll: -4',
+        'Attack roll: -1',
         'first attack: miss should have expected detail text',
       );
     }

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -95,7 +95,11 @@ module('Unit | Utils | attack', function (hooks) {
 
     // This attack rolls 3 + 4 = 7, so it should miss
     const attackData = attack.makeAttack(10, false, false);
-    assert.strictEqual(attackData.roll, 7, 'attack should have rolled a 7');
+    assert.deepEqual(
+      attackData.roll,
+      { total: 7, rolls: [{ name: '1d20', rolls: [3] }] },
+      'attack should have rolled a 7',
+    );
     assert.false(attackData.hit, 'attack should have missed');
     assert.false(attackData.crit, 'attack was not a crit');
     assert.false(attackData.nat1, 'attack was not a nat 1');
@@ -116,9 +120,9 @@ module('Unit | Utils | attack', function (hooks) {
 
     // This attack rolls a nat 1, so it should miss even though 1 + 20 > 10
     const attackData = attack.makeAttack(10, false, false);
-    assert.strictEqual(
+    assert.deepEqual(
       attackData.roll,
-      21,
+      { total: 21, rolls: [{ name: '1d20', rolls: [1] }] },
       'attack should have rolled a 21 total',
     );
     assert.false(attackData.hit, 'attack should have missed');
@@ -146,9 +150,9 @@ module('Unit | Utils | attack', function (hooks) {
     // Do not fake the damage dice; this test is focused on the hit
 
     const attackData = attack.makeAttack(15, false, false);
-    assert.strictEqual(
+    assert.deepEqual(
       attackData.roll,
-      18,
+      { total: 18, rolls: [{ name: '1d20', rolls: [13] }] },
       'attack should have rolled an 18 total (13 + 5)',
     );
     assert.true(attackData.hit, 'attack should have hit');
@@ -185,9 +189,15 @@ module('Unit | Utils | attack', function (hooks) {
     // this test
 
     const attackData = attack.makeAttack(15, false, false);
-    assert.strictEqual(
+    assert.deepEqual(
       attackData.roll,
-      20,
+      {
+        total: 20,
+        rolls: [
+          { name: '1d20', rolls: [13] },
+          { name: '1d4', rolls: [2] },
+        ],
+      },
       'attack should have rolled a 20 total (13 + 5 + 2)',
     );
     assert.true(attackData.hit, 'attack should have hit');
@@ -197,6 +207,45 @@ module('Unit | Utils | attack', function (hooks) {
       attackData.damage > 0,
       'some damage should have been inflicted',
     );
+  });
+
+  test('it handles a hit with an attack modifier subtracting dice correctly', async function (assert) {
+    const attack = new Attack('5 - 1d6', [
+      new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name),
+      new Damage('2d8', DamageType.RADIANT.name),
+    ]);
+
+    // Fake the results of the d20 attack roll
+    const fakeD20 = sinon.stub();
+    fakeD20.onCall(0).returns(13);
+    fakeD20.onCall(1).returns(3);
+    attack.die.roll = fakeD20;
+
+    const fake1d6 = sinon.fake.returns({
+      total: 6,
+      rolls: [6],
+    });
+    const attack1d6 = attack.toHitModifier.diceGroups[0];
+    if (attack1d6) {
+      attack1d6.roll = fake1d6;
+    }
+
+    // Do not mock the results of the damage dice since it's not the focus of
+    // this test
+
+    const attackData = attack.makeAttack(15, false, false);
+    assert.deepEqual(
+      attackData.roll,
+      {
+        total: 12,
+        rolls: [
+          { name: '1d20', rolls: [13] },
+          { name: '-1d6', rolls: [6] },
+        ],
+      },
+      'attack should have rolled a 20 total (13 + 5 + 2)',
+    );
+    assert.false(attackData.hit, 'attack should not have hit');
   });
 
   test('it adds damage dice as expected', async function (assert) {
@@ -251,9 +300,9 @@ module('Unit | Utils | attack', function (hooks) {
     const attackData = attack.makeAttack(15, false, false);
     fakePiercing.alwaysCalledWith(false);
     fakeRadiant.alwaysCalledWith(false);
-    assert.strictEqual(
+    assert.deepEqual(
       attackData.roll,
-      18,
+      { total: 18, rolls: [{ name: '1d20', rolls: [13] }] },
       'attack should have rolled an 18 total (13 + 5)',
     );
     assert.true(attackData.hit, 'attack should have hit');
@@ -339,9 +388,9 @@ module('Unit | Utils | attack', function (hooks) {
     const attackData = attack.makeAttack(25, false, false);
     fakePiercing.alwaysCalledWith(true);
     fakeRadiant.alwaysCalledWith(true);
-    assert.strictEqual(
+    assert.deepEqual(
       attackData.roll,
-      15,
+      { total: 15, rolls: [{ name: '1d20', rolls: [20] }] },
       'attack should have rolled an 15 total (20 - 5)',
     );
     assert.true(

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -212,7 +212,7 @@ module('Unit | Utils | attack', function (hooks) {
     attack.die.roll = fakeD20;
 
     // Fake the results of the damage dice
-    const fakePiercing = sinon.fake.returns({
+    const fakePiercingDamageDetails = {
       total: 13,
       rolls: [
         {
@@ -224,8 +224,10 @@ module('Unit | Utils | attack', function (hooks) {
           rolls: [1],
         },
       ],
-    });
-    const fakeRadiant = sinon.fake.returns({
+    };
+    const fakePiercing = sinon.fake.returns(fakePiercingDamageDetails);
+
+    const fakeRadiantDamageDetails = {
       total: 7,
       rolls: [
         {
@@ -233,7 +235,8 @@ module('Unit | Utils | attack', function (hooks) {
           rolls: [6, 1],
         },
       ],
-    });
+    };
+    const fakeRadiant = sinon.fake.returns(fakeRadiantDamageDetails);
 
     const piercing: Damage | undefined = attack.damageTypes[0];
     if (piercing) {
@@ -265,14 +268,14 @@ module('Unit | Utils | attack', function (hooks) {
       {
         type: 'piercing',
         dice: '2d6 + 1d4 + 5',
-        roll: 13,
+        roll: fakePiercingDamageDetails,
         resisted: false,
         vulnerable: false,
       },
       {
         type: 'radiant',
         dice: '2d8',
-        roll: 7,
+        roll: fakeRadiantDamageDetails,
         resisted: false,
         vulnerable: false,
       },
@@ -297,7 +300,7 @@ module('Unit | Utils | attack', function (hooks) {
     attack.die.roll = fakeD20;
 
     // Fake the results of the damage dice
-    const fakePiercing = sinon.fake.returns({
+    const fakePiercingDamageDetails = {
       total: 25,
       rolls: [
         {
@@ -309,8 +312,10 @@ module('Unit | Utils | attack', function (hooks) {
           rolls: [1, 4],
         },
       ],
-    });
-    const fakeRadiant = sinon.fake.returns({
+    };
+    const fakePiercing = sinon.fake.returns(fakePiercingDamageDetails);
+
+    const fakeRadiantDamageDetails = {
       total: 14,
       rolls: [
         {
@@ -318,7 +323,8 @@ module('Unit | Utils | attack', function (hooks) {
           rolls: [3, 1, 8, 2],
         },
       ],
-    });
+    };
+    const fakeRadiant = sinon.fake.returns(fakeRadiantDamageDetails);
 
     const piercing: Damage | undefined = attack.damageTypes[0];
     if (piercing) {
@@ -353,14 +359,14 @@ module('Unit | Utils | attack', function (hooks) {
       {
         type: 'piercing',
         dice: '4d6 + 2d4 + 5',
-        roll: 25,
+        roll: fakePiercingDamageDetails,
         resisted: false,
         vulnerable: false,
       },
       {
         type: 'radiant',
         dice: '4d8',
-        roll: 14,
+        roll: fakeRadiantDamageDetails,
         resisted: false,
         vulnerable: false,
       },

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -212,8 +212,28 @@ module('Unit | Utils | attack', function (hooks) {
     attack.die.roll = fakeD20;
 
     // Fake the results of the damage dice
-    const fakePiercing = sinon.fake.returns(13);
-    const fakeRadiant = sinon.fake.returns(7);
+    const fakePiercing = sinon.fake.returns({
+      total: 13,
+      rolls: [
+        {
+          name: '2d6',
+          rolls: [3, 4],
+        },
+        {
+          name: '1d4',
+          rolls: [1],
+        },
+      ],
+    });
+    const fakeRadiant = sinon.fake.returns({
+      total: 7,
+      rolls: [
+        {
+          name: '2d8',
+          rolls: [6, 1],
+        },
+      ],
+    });
 
     const piercing: Damage | undefined = attack.damageTypes[0];
     if (piercing) {
@@ -277,8 +297,28 @@ module('Unit | Utils | attack', function (hooks) {
     attack.die.roll = fakeD20;
 
     // Fake the results of the damage dice
-    const fakePiercing = sinon.fake.returns(25);
-    const fakeRadiant = sinon.fake.returns(14);
+    const fakePiercing = sinon.fake.returns({
+      total: 25,
+      rolls: [
+        {
+          name: '4d6',
+          rolls: [3, 4, 6, 2],
+        },
+        {
+          name: '2d4',
+          rolls: [1, 4],
+        },
+      ],
+    });
+    const fakeRadiant = sinon.fake.returns({
+      total: 14,
+      rolls: [
+        {
+          name: '4d8',
+          rolls: [3, 1, 8, 2],
+        },
+      ],
+    });
 
     const piercing: Damage | undefined = attack.damageTypes[0];
     if (piercing) {

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -172,7 +172,10 @@ module('Unit | Utils | attack', function (hooks) {
     fakeD20.onCall(1).returns(3);
     attack.die.roll = fakeD20;
 
-    const fake1d4 = sinon.fake.returns(2);
+    const fake1d4 = sinon.fake.returns({
+      total: 2,
+      rolls: [2],
+    });
     const attack1d4 = attack.toHitModifier.diceGroups[0];
     if (attack1d4) {
       attack1d4.roll = fake1d4;

--- a/tests/unit/utils/damage-test.ts
+++ b/tests/unit/utils/damage-test.ts
@@ -139,6 +139,38 @@ module('Unit | Utils | damage', function (hooks) {
     );
   });
 
+  test('it does not allow damage to be negative', async function (assert) {
+    const damage = new Damage('1d4 - 3', DamageType.RADIANT.name, true);
+
+    assert.strictEqual(
+      damage.damage.diceGroups.length,
+      1,
+      'damage should roll one group of dice',
+    );
+
+    const fakeD4 = sinon.stub();
+    fakeD4.onCall(0).returns(1);
+    fakeD4.onCall(1).returns(2);
+    const group1d4: DiceGroup | undefined = damage.damage.diceGroups[0];
+    if (group1d4) {
+      group1d4.die.roll = fakeD4;
+    }
+
+    assert.deepEqual(
+      damage.roll(false),
+      {
+        total: 0,
+        rolls: [
+          {
+            name: '1d4',
+            rolls: [1],
+          },
+        ],
+      },
+      'roll should inflict 1 - 3 = 0 total damage (damage cannot be negative)',
+    );
+  });
+
   test('it halves damage for resistant targets', async function (assert) {
     const damage = new Damage('2d6 + 1', DamageType.RADIANT.name, true);
 

--- a/tests/unit/utils/damage-test.ts
+++ b/tests/unit/utils/damage-test.ts
@@ -25,9 +25,17 @@ module('Unit | Utils | damage', function (hooks) {
       group1d6.die.roll = fake1d6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       damage.roll(false),
-      4,
+      {
+        total: 4,
+        rolls: [
+          {
+            name: '1d6',
+            rolls: [3],
+          },
+        ],
+      },
       'roll should inflict 3 + 1 = 4 total damage',
     );
   });
@@ -60,9 +68,21 @@ module('Unit | Utils | damage', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       damage.roll(false),
-      21,
+      {
+        total: 21,
+        rolls: [
+          {
+            name: '3d8',
+            rolls: [3, 7, 5],
+          },
+          {
+            name: '2d6',
+            rolls: [1, 4],
+          },
+        ],
+      },
       'roll should inflict (3 + 7 + 5) + (1 + 4) + 1 = 21 total damage',
     );
   });
@@ -100,9 +120,21 @@ module('Unit | Utils | damage', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       damage.roll(true),
-      34,
+      {
+        total: 34,
+        rolls: [
+          {
+            name: '6d8',
+            rolls: [3, 7, 5, 5, 1, 2],
+          },
+          {
+            name: '4d6',
+            rolls: [1, 4, 2, 2],
+          },
+        ],
+      },
       'roll should inflict 22 + (5 + 1 + 2) + (2 + 2) = 34 total damage',
     );
   });
@@ -124,9 +156,17 @@ module('Unit | Utils | damage', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       damage.roll(false),
-      4,
+      {
+        total: 4,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
       'roll should inflict (3 + 5 + 1) / 2 = 4 total damage',
     );
   });
@@ -148,9 +188,17 @@ module('Unit | Utils | damage', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       damage.roll(false),
-      18,
+      {
+        total: 18,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
       'roll should inflict (3 + 5 + 1) * 2 = 18 total damage',
     );
   });
@@ -172,9 +220,17 @@ module('Unit | Utils | damage', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       damage.roll(false),
-      8,
+      {
+        total: 8,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
       'roll should inflict ((3 + 5 + 1) / 2) * 2 = 8 total damage',
     );
   });

--- a/tests/unit/utils/dice-group-test.ts
+++ b/tests/unit/utils/dice-group-test.ts
@@ -22,7 +22,7 @@ module('Unit | Utils | dice-group', function (hooks) {
 
   test('it rolls and totals multiple dice', async function (assert) {
     const noDice = new DiceGroup(0, 6);
-    assert.strictEqual(
+    assert.deepEqual(
       noDice.roll(),
       {
         total: 0,
@@ -46,7 +46,7 @@ module('Unit | Utils | dice-group', function (hooks) {
     assert.true(group1d8.shouldAdd(), 'dice group should be added by default');
 
     group1d8.die.roll = sinon.fake.returns(3);
-    assert.strictEqual(
+    assert.deepEqual(
       group1d8.roll(),
       {
         total: 3,
@@ -78,12 +78,12 @@ module('Unit | Utils | dice-group', function (hooks) {
     fakeDie.onCall(2).returns(5);
 
     group3d6.die.roll = fakeDie;
-    // 1 + 3 + 5 = 9 expected sum
-    assert.strictEqual(
+    // 3 + 1 + 5 = 9 expected sum
+    assert.deepEqual(
       group3d6.roll(),
       {
         total: 9,
-        rolls: [1, 3, 5],
+        rolls: [3, 1, 5],
       },
       'roll of multiple dice should return expected sum',
     );

--- a/tests/unit/utils/dice-group-test.ts
+++ b/tests/unit/utils/dice-group-test.ts
@@ -24,7 +24,10 @@ module('Unit | Utils | dice-group', function (hooks) {
     const noDice = new DiceGroup(0, 6);
     assert.strictEqual(
       noDice.roll(),
-      0,
+      {
+        total: 0,
+        rolls: [],
+      },
       'rolling no dice should never result in a total',
     );
 
@@ -45,7 +48,10 @@ module('Unit | Utils | dice-group', function (hooks) {
     group1d8.die.roll = sinon.fake.returns(3);
     assert.strictEqual(
       group1d8.roll(),
-      3,
+      {
+        total: 3,
+        rolls: [3],
+      },
       'roll of a single die should return expected sum',
     );
 
@@ -75,7 +81,10 @@ module('Unit | Utils | dice-group', function (hooks) {
     // 1 + 3 + 5 = 9 expected sum
     assert.strictEqual(
       group3d6.roll(),
-      9,
+      {
+        total: 9,
+        rolls: [1, 3, 5],
+      },
       'roll of multiple dice should return expected sum',
     );
   });

--- a/tests/unit/utils/dice-groups-and-modifier-test.ts
+++ b/tests/unit/utils/dice-groups-and-modifier-test.ts
@@ -14,11 +14,11 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       1,
     );
 
-    const fake1d6 = sinon.stub();
-    fake1d6.onCall(0).returns(3);
+    const fakeD6 = sinon.stub();
+    fakeD6.onCall(0).returns(3);
     const group1d6: DiceGroup | undefined = diceGroupAndModifier.diceGroups[0];
     if (group1d6) {
-      group1d6.die.roll = fake1d6;
+      group1d6.die.roll = fakeD6;
     }
 
     assert.strictEqual(

--- a/tests/unit/utils/dice-groups-and-modifier-test.ts
+++ b/tests/unit/utils/dice-groups-and-modifier-test.ts
@@ -21,9 +21,17 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       group1d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
-      diceGroupAndModifier.rollAndGetTotal(false),
-      4,
+    assert.deepEqual(
+      diceGroupAndModifier.roll(false),
+      {
+        total: 4,
+        rolls: [
+          {
+            name: '1d6',
+            rolls: [3],
+          },
+        ],
+      },
       'roll should total 3 + 1 = 4',
     );
   });
@@ -42,9 +50,17 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       group1d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
-      diceGroupAndModifier.rollAndGetTotal(true),
-      9,
+    assert.deepEqual(
+      diceGroupAndModifier.roll(true),
+      {
+        total: 9,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 4],
+          },
+        ],
+      },
       'roll should inflict 3 + 4 + 2 = 9 total damage on a critical hit',
     );
   });
@@ -75,8 +91,20 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
     }
 
     assert.strictEqual(
-      diceGroupAndModifier.rollAndGetTotal(false),
-      7,
+      diceGroupAndModifier.roll(false),
+      {
+        total: 7,
+        rolls: [
+          {
+            name: '3d8',
+            rolls: [3, 7, 5],
+          },
+          {
+            name: '2d6',
+            rolls: [1, 4],
+          },
+        ],
+      },
       'roll should inflict (3 + 7 + 5) - (1 + 4) - 3 = 7 total damage',
     );
   });
@@ -112,8 +140,20 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
     }
 
     assert.strictEqual(
-      diceGroupAndModifier.rollAndGetTotal(true),
-      34,
+      diceGroupAndModifier.roll(true),
+      {
+        total: 34,
+        rolls: [
+          {
+            name: '6d8',
+            rolls: [3, 7, 5, 5, 1, 2],
+          },
+          {
+            name: '4d6',
+            rolls: [1, 4, 2, 2],
+          },
+        ],
+      },
       'roll should inflict 22 + (5 + 1 + 2) + (2 + 2) = 34 total damage',
     );
   });

--- a/tests/unit/utils/dice-groups-and-modifier-test.ts
+++ b/tests/unit/utils/dice-groups-and-modifier-test.ts
@@ -90,7 +90,7 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       diceGroupAndModifier.roll(false),
       {
         total: 7,
@@ -100,7 +100,7 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
             rolls: [3, 7, 5],
           },
           {
-            name: '2d6',
+            name: '-2d6',
             rolls: [1, 4],
           },
         ],
@@ -139,7 +139,7 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       group2d6.die.roll = fakeD6;
     }
 
-    assert.strictEqual(
+    assert.deepEqual(
       diceGroupAndModifier.roll(true),
       {
         total: 34,


### PR DESCRIPTION
This adds hovertext to all dice rolls which displays the values rolled on the dice. This allows users to manually handle various edge cases without re-rolling the dice--for instance, if a monk uses Deflect Missiles to reduce the damage from an incoming attack, and then resistance should only be applied to the remaining damage, the damage can be recalculated using the rolled dice. 

![image](https://github.com/jbpeirce/multiattack-5e/assets/13395970/0bf09431-96e9-45fa-9734-8b9cba103594)

![image](https://github.com/jbpeirce/multiattack-5e/assets/13395970/8f0adb29-2f91-450c-9466-0ac1a79f29a5)
