### PR TITLE
Test with fake dice

### DIFF
--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -38,12 +38,14 @@
         <li class="li-hit">
           <span data-test-attack-roll-detail="{{index}}-{{index2}}"
             title="{{this.getRollDetailString attackDetails.roll.rolls}}">
-            <a class="link link-dark" data-bs-toggle="collapse" href="#attack-detail-collapse-{{index}}-{{index2}}"
-              role="button" aria-expanded="false" aria-controls="attack-detail-collapse-{{index}}-{{index2}}">
+            <a data-test-attack-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
+              data-bs-toggle="collapse" href="#attack-detail-collapse-{{index}}-{{index2}}" role="button"
+              aria-expanded="false" aria-controls="attack-detail-collapse-{{index}}-{{index2}}">
               {{attackDetails.roll.total}}</a> to hit
             {{#if attackDetails.crit}} (CRIT!){{/if}}
           </span>
-          <div class="collapse" id="attack-detail-collapse-{{index}}-{{index2}}">
+          <div data-test-attack-roll-collapse-pane="{{index}}-{{index2}}" class="collapse"
+            id="attack-detail-collapse-{{index}}-{{index2}}">
             <ul>
               {{#each attackDetails.roll.rolls as |roll|}}
               <li class="text-muted">
@@ -58,7 +60,7 @@
             <li>
               <span data-test-damage-roll-detail="{{index}}-{{index2}}-{{index3}}"
                 title="{{this.getRollDetailString damage.roll.rolls}}">
-                <a data-test-damage-roll-collapse-link="{{index}}-{{index2}}-{{index3}}" class="link link-dark"
+                <a data-test-damage-roll-collapse-link="{{index}}-{{index2}}-{{index3}}" class="link link-dark collapsed"
                   data-bs-toggle="collapse" href="#damage-detail-collapse-{{index}}-{{index2}}-{{index3}}" role="button"
                   aria-expanded="false"
                   aria-controls="damage-detail-collapse-{{index}}-{{index2}}-{{index3}}">{{damage.roll.total}}</a>
@@ -89,12 +91,12 @@
         <li class="li-miss">
           <span data-test-attack-roll-detail="{{index}}-{{index2}}"
             title="{{this.getRollDetailString attackDetails.roll.rolls}}">
-            <a class="link link-dark" data-bs-toggle="collapse" href="#attack-detail-collapse-{{index}}-{{index2}}"
+            <a data-test-attack-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed" data-bs-toggle="collapse" href="#attack-detail-collapse-{{index}}-{{index2}}"
               role="button" aria-expanded="false" aria-controls="attack-detail-collapse-{{index}}-{{index2}}">
               {{attackDetails.roll.total}}</a> to hit
             {{#if attackDetails.nat1}} (NAT 1!){{/if}}
           </span>
-          <div class="collapse" id="attack-detail-collapse-{{index}}-{{index2}}">
+          <div data-test-attack-roll-collapse-pane="{{index}}-{{index2}}"  class="collapse" id="attack-detail-collapse-{{index}}-{{index2}}">
             <ul>
               {{#each attackDetails.roll.rolls as |roll|}}
               <li class="text-muted">

--- a/app/services/randomness.ts
+++ b/app/services/randomness.ts
@@ -1,0 +1,13 @@
+import Service from '@ember/service';
+
+export default class RandomnessService extends Service {
+  /**
+   * Return a pseudorandom number between 0 and 1. This is typically
+   * implemented using Math.random() or a similar tool, but can be overridden
+   * to hardcode randomness during tests.
+   * @returns a pseudorandom number between 0 and 1
+   */
+  random() {
+    return Math.random();
+  }
+}

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -1,3 +1,5 @@
+import type RandomnessService from 'multiattack-5e/services/randomness';
+
 import Damage from './damage';
 import DiceGroupsAndModifier, {
   type GroupRollDetails,
@@ -24,7 +26,7 @@ export interface DamageDetails {
 }
 
 export default class Attack {
-  die = new Die(20);
+  die: Die;
 
   toHitModifier: DiceGroupsAndModifier;
 
@@ -38,8 +40,13 @@ export default class Attack {
    * @param damageTypes a list of the damage types inflicted by this attack,
    * with details for each
    */
-  constructor(toHit: string, damageTypes: Damage[]) {
-    this.toHitModifier = DiceStringParser.parse(toHit);
+  constructor(
+    toHit: string,
+    damageTypes: Damage[],
+    randomness: RandomnessService,
+  ) {
+    this.die = new Die(20, randomness);
+    this.toHitModifier = DiceStringParser.parse(toHit, randomness);
     this.damageTypes = damageTypes;
   }
 

--- a/app/utils/damage.ts
+++ b/app/utils/damage.ts
@@ -2,6 +2,8 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+import type RandomnessService from 'multiattack-5e/services/randomness';
+
 import DiceGroupsAndModifier, {
   type GroupRollDetails,
 } from './dice-groups-and-modifier';
@@ -17,12 +19,17 @@ export default class Damage {
   @tracked targetResistant: boolean;
   @tracked targetVulnerable: boolean;
 
+  randomness: RandomnessService;
+
   constructor(
     damageString: string,
     type: string,
+    randomness: RandomnessService,
     targetResistant = false,
     targetVulnerable = false,
   ) {
+    this.randomness = randomness;
+
     this.parseDamageString(damageString);
     this.damageString = damageString;
     this.type = type;
@@ -32,7 +39,7 @@ export default class Damage {
 
   parseDamageString(damageString: string) {
     try {
-      this.damage = DiceStringParser.parse(damageString);
+      this.damage = DiceStringParser.parse(damageString, this.randomness);
       this.damageParsingErrored = false;
     } catch (e) {
       this.damage = new DiceGroupsAndModifier([], 0);

--- a/app/utils/dice-group.ts
+++ b/app/utils/dice-group.ts
@@ -1,3 +1,4 @@
+import type RandomnessService from 'multiattack-5e/services/randomness';
 import Die from 'multiattack-5e/utils/die';
 
 export interface RollDetails {
@@ -10,13 +11,18 @@ export default class DiceGroup {
   die: Die;
   add: boolean;
 
-  constructor(numDice: number, numSides: number, add = true) {
+  constructor(
+    numDice: number,
+    numSides: number,
+    randomness: RandomnessService,
+    add = true,
+  ) {
     if (numDice < 0) {
       throw new Error('Number of dice in group must be non-negative');
     }
 
     this.numDice = numDice;
-    this.die = new Die(numSides);
+    this.die = new Die(numSides, randomness);
     this.add = add;
   }
 

--- a/app/utils/dice-string-parser.ts
+++ b/app/utils/dice-string-parser.ts
@@ -1,3 +1,5 @@
+import type RandomnessService from 'multiattack-5e/services/randomness';
+
 import DiceGroup from './dice-group';
 import DiceGroupsAndModifier from './dice-groups-and-modifier';
 
@@ -45,7 +47,10 @@ export default class DiceStringParser {
    * @returns the list of described dice groups and all of the numbers added
    * together into a single modifier
    */
-  static parse(diceString: string): DiceGroupsAndModifier {
+  static parse(
+    diceString: string,
+    randomness: RandomnessService,
+  ): DiceGroupsAndModifier {
     // Check that the string matches the overall expected pattern, with no
     // additional text or missing signs
     if (!this.validateDiceString(diceString)) {
@@ -76,6 +81,7 @@ export default class DiceStringParser {
           new DiceGroup(
             Number(match.groups['numDice']),
             Number(match.groups['numSides']),
+            randomness,
             add,
           ),
         );

--- a/app/utils/die.ts
+++ b/app/utils/die.ts
@@ -1,11 +1,15 @@
+import RandomnessService from 'multiattack-5e/services/randomness';
+
 export default class Die {
   sides: number;
+  randomness: RandomnessService;
 
-  constructor(sides: number) {
+  constructor(sides: number, randomness: RandomnessService) {
     if (sides < 1) {
       throw new Error('Die must have a positive number of sides');
     }
     this.sides = sides;
+    this.randomness = randomness;
   }
 
   /**
@@ -13,6 +17,6 @@ export default class Die {
    * die, as though rolling a physical die
    */
   roll(): number {
-    return Math.floor(Math.random() * this.sides) + 1;
+    return Math.floor(this.randomness.random() * this.sides) + 1;
   }
 }

--- a/app/utils/repeated-attack.ts
+++ b/app/utils/repeated-attack.ts
@@ -1,4 +1,5 @@
 import AdvantageState from 'multiattack-5e/components/advantage-state-enum';
+import type RandomnessService from 'multiattack-5e/services/randomness';
 
 import Attack, { type AttackDetails } from './attack';
 import type Damage from './damage';
@@ -25,18 +26,22 @@ export default class RepeatedAttack {
   damageList: Damage[];
   advantageState: AdvantageState;
 
+  randomness: RandomnessService;
+
   constructor(
     numberOfAttacks: number,
     targetAC: number,
     toHit: string,
     damageList: Damage[],
     advantageState: AdvantageState,
+    randomness: RandomnessService,
   ) {
     this.numberOfAttacks = numberOfAttacks;
     this.targetAC = targetAC;
     this.toHit = toHit;
     this.damageList = damageList;
     this.advantageState = advantageState;
+    this.randomness = randomness;
   }
 
   /**
@@ -82,7 +87,11 @@ export default class RepeatedAttack {
     let totalNumberOfHits = 0;
     const attackDetailsList = [];
 
-    const attack = new Attack(this.toHit, this.damageList.toArray());
+    const attack = new Attack(
+      this.toHit,
+      this.damageList.toArray(),
+      this.randomness,
+    );
 
     for (let i = 0; i < this.numberOfAttacks; i++) {
       const attackDetails = attack.makeAttack(

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -1,0 +1,217 @@
+import { click, fillIn, select, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import DamageType from 'multiattack-5e/components/damage-type-enum';
+import type RandomnessService from 'multiattack-5e/services/randomness';
+
+import { type ElementContext } from '../types/element-context';
+
+module('Acceptance | repeated attack form', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('performing single attack set with maximized dice', async function (this: ElementContext, assert) {
+    // Mock randomness so that all dice roll their maximum value
+    const fakeRandom = sinon.fake.returns(0.99999999999999);
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+
+    // Fill in some details for the attack
+    await fillIn('[data-test-input-numberOfAttacks]', '2');
+    await fillIn('[data-test-input-targetAC]', '15');
+    await fillIn('[data-test-input-toHit]', '3 - 1D6');
+    await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
+    await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
+    await click('[data-test-value="advantage"]');
+    await click('[data-test-value="straight"]');
+    await click('[data-test-input-resistant="0"]');
+
+    // Calculate the attack
+    await click('[data-test-button-getDamage]');
+
+    assert
+      .dom('[data-test-attack-data-list="0"]')
+      .hasText(
+        'Number of attacks: 2\n' +
+          'Target AC: 15\n' +
+          'Attack roll: 1d20 - 1d6 + 3\n',
+        'the details for the input damage should be displayed',
+      );
+
+    // Both attacks were a critical hit, so each dealt 12 + 12 + 5 = 29 damage,
+    // halved to 14 by resistance
+    assert
+      .dom('[data-test-total-damage-header="0"]')
+      .hasText('Total Damage: 28 (2 hits)');
+
+    // Check that the displayed text matches the expected die rolls (other
+    // tests check additional details of the display). Since all dice are
+    // maximized, the two attacks are identical.
+    for (let i = 0; i < 2; i++) {
+      // Examine the attack roll section
+      assert
+        .dom(`[data-test-attack-roll-detail="0-${i}"]`)
+        .hasAttribute('title', '1d20: 20 | -1d6: 6')
+        .hasText('17 to hit (CRIT!)');
+
+      // Test the collapsible attack-roll details
+      assert
+        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .hasAria('expanded', 'false')
+        .hasText('17');
+      assert
+        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .hasText('1d20: 20 -1d6: 6')
+        .doesNotHaveClass(
+          'show',
+          'attack roll detail pane should start collapsed',
+        );
+
+      // The attack roll details should be visible after a click
+      await click(`[data-test-attack-roll-collapse-link="0-${i}"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, attack roll detail pane should be expanded',
+        );
+      assert
+        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .hasClass(
+          'show',
+          'after click, attack roll detail pane should be visible',
+        );
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
+
+      // Examine the damage section
+      assert
+        .dom(`[data-test-damage-roll-detail="0-${i}-0"]`)
+        .hasAttribute('title', '2d12: 12, 12')
+        .hasText('14 radiant damage (2d12 + 5) (resisted)');
+
+      // Test the collapsible damage pane
+      assert
+        .dom(`[data-test-damage-roll-collapse-link="0-${i}-0"]`)
+        .hasAria('expanded', 'false')
+        .hasText('14');
+      assert
+        .dom(`[data-test-damage-roll-collapse-pane="0-${i}-0"]`)
+        .hasText('2d12: 12, 12');
+
+      // The damage roll details should be visible after a click
+      await click(`[data-test-damage-roll-collapse-link="0-${i}-0"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`[data-test-damage-roll-collapse-link="0-${i}-0"]`)
+        .hasAria('expanded', 'true');
+      assert
+        .dom(`[data-test-damage-roll-collapse-pane="0-${i}-0"]`)
+        .hasClass('show');
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
+    }
+  });
+
+  test('performing single attack set with minimized dice', async function (this: ElementContext, assert) {
+    // Mock randomness so that all dice roll their minimum value
+    const fakeRandom = sinon.fake.returns(0);
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+
+    // Fill in some details for the attack
+    await fillIn('[data-test-input-numberOfAttacks]', '2');
+    await fillIn('[data-test-input-targetAC]', '15');
+    await fillIn('[data-test-input-toHit]', '3 - 1D6');
+    await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
+    await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
+    await click('[data-test-value="advantage"]');
+    await click('[data-test-value="straight"]');
+    await click('[data-test-input-resistant="0"]');
+
+    // Calculate the attack
+    await click('[data-test-button-getDamage]');
+
+    assert
+      .dom('[data-test-attack-data-list="0"]')
+      .hasText(
+        'Number of attacks: 2\n' +
+          'Target AC: 15\n' +
+          'Attack roll: 1d20 - 1d6 + 3\n',
+        'the details for the input damage should be displayed',
+      );
+
+    // Both attacks were a natural one
+    assert
+      .dom('[data-test-total-damage-header="0"]')
+      .hasText('Total Damage: 0 (0 hits)');
+
+    // Check that the displayed text matches the expected die rolls (other
+    // tests check additional details of the display). Since all dice are
+    // minimized, the two attacks are identical.
+    for (let i = 0; i < 2; i++) {
+      // Examine the attack roll section
+      assert
+        .dom(`[data-test-attack-roll-detail="0-${i}"]`)
+        .hasAttribute('title', '1d20: 1 | -1d6: 1')
+        .hasText('3 to hit (NAT 1!)');
+
+      // Test the collapsible attack-roll details
+      assert
+        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .hasAria('expanded', 'false')
+        .hasText('3');
+      assert
+        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .hasText('1d20: 1 -1d6: 1')
+        .doesNotHaveClass(
+          'show',
+          'attack roll detail pane should start collapsed',
+        );
+
+      // The attack roll details should be visible after a click
+      await click(`[data-test-attack-roll-collapse-link="0-${i}"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, attack roll detail pane should be expanded',
+        );
+      assert
+        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .hasClass(
+          'show',
+          'after click, attack roll detail pane should be visible',
+        );
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
+
+      // The damage section should be empty
+      assert.dom(`[data-test-damage-roll-detail="0-${i}-0"]`).doesNotExist();
+    }
+  });
+
+  function delay() {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+});

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -5,6 +5,7 @@ import { module, test } from 'qunit';
 
 import AdvantageState from 'multiattack-5e/components/advantage-state-enum';
 import DamageType from 'multiattack-5e/components/damage-type-enum';
+import RandomnessService from 'multiattack-5e/services/randomness';
 import { type ElementContext } from 'multiattack-5e/tests/types/element-context';
 import Damage from 'multiattack-5e/utils/damage';
 
@@ -18,8 +19,20 @@ module('Integration | Component | detail-display', function (hooks) {
         targetAC: 15,
         toHit: '3 - 1d6',
         damageList: [
-          new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name, true, false),
-          new Damage('2d8', DamageType.RADIANT.name, false, true),
+          new Damage(
+            '2d6 + 5 + 1d4',
+            DamageType.PIERCING.name,
+            new RandomnessService(),
+            true,
+            false,
+          ),
+          new Damage(
+            '2d8',
+            DamageType.RADIANT.name,
+            new RandomnessService(),
+            false,
+            true,
+          ),
         ],
         advantageState: AdvantageState.DISADVANTAGE,
         totalDmg: 62,
@@ -347,8 +360,20 @@ module('Integration | Component | detail-display', function (hooks) {
         targetAC: 15,
         toHit: '-3',
         damageList: [
-          new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name, true, false),
-          new Damage('2d8', DamageType.RADIANT.name, false, true),
+          new Damage(
+            '2d6 + 5 + 1d4',
+            DamageType.PIERCING.name,
+            new RandomnessService(),
+            true,
+            false,
+          ),
+          new Damage(
+            '2d8',
+            DamageType.RADIANT.name,
+            new RandomnessService(),
+            false,
+            true,
+          ),
         ],
         advantageState: AdvantageState.STRAIGHT,
         totalDmg: 25,
@@ -469,8 +494,20 @@ module('Integration | Component | detail-display', function (hooks) {
         targetAC: 15,
         toHit: '-3',
         damageList: [
-          new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name, true, false),
-          new Damage('2d8', DamageType.RADIANT.name, false, true),
+          new Damage(
+            '2d6 + 5 + 1d4',
+            DamageType.PIERCING.name,
+            new RandomnessService(),
+            true,
+            false,
+          ),
+          new Damage(
+            '2d8',
+            DamageType.RADIANT.name,
+            new RandomnessService(),
+            false,
+            true,
+          ),
         ],
         advantageState: AdvantageState.STRAIGHT,
         totalDmg: 15,
@@ -548,7 +585,15 @@ module('Integration | Component | detail-display', function (hooks) {
         numberOfAttacks: 1,
         targetAC: 14,
         toHit: '3',
-        damageList: [new Damage('3d6', DamageType.ACID.name, true, true)],
+        damageList: [
+          new Damage(
+            '3d6',
+            DamageType.ACID.name,
+            new RandomnessService(),
+            true,
+            true,
+          ),
+        ],
         advantageState: AdvantageState.ADVANTAGE,
         totalDmg: 10,
         totalNumberOfHits: 1,

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import DamageType from 'multiattack-5e/components/damage-type-enum';
+import RandomnessService from 'multiattack-5e/services/randomness';
 import Attack, { type DamageDetails } from 'multiattack-5e/utils/attack';
 import Damage from 'multiattack-5e/utils/damage';
 
@@ -14,7 +15,7 @@ module('Unit | Utils | attack', function (hooks) {
     fakeD20.onCall(0).returns(3);
     fakeD20.onCall(1).returns(7);
 
-    const attack = new Attack('4', []);
+    const attack = new Attack('4', [], new RandomnessService());
     attack.die.roll = fakeD20;
 
     assert.strictEqual(
@@ -29,7 +30,7 @@ module('Unit | Utils | attack', function (hooks) {
     fakeD20.onCall(0).returns(3);
     fakeD20.onCall(1).returns(7);
 
-    const attack = new Attack('4', []);
+    const attack = new Attack('4', [], new RandomnessService());
     attack.die.roll = fakeD20;
 
     assert.strictEqual(
@@ -44,7 +45,7 @@ module('Unit | Utils | attack', function (hooks) {
     fakeD20.onCall(0).returns(3);
     fakeD20.onCall(1).returns(7);
 
-    const attack = new Attack('4', []);
+    const attack = new Attack('4', [], new RandomnessService());
     attack.die.roll = fakeD20;
 
     assert.strictEqual(
@@ -67,7 +68,7 @@ module('Unit | Utils | attack', function (hooks) {
     fakeD20.onCall(0).returns(3);
     fakeD20.onCall(1).returns(7);
 
-    const attack = new Attack('4', []);
+    const attack = new Attack('4', [], new RandomnessService());
     attack.die.roll = fakeD20;
 
     assert.strictEqual(
@@ -86,7 +87,7 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it handles an AC-based miss correctly', async function (assert) {
-    const attack = new Attack('4', []);
+    const attack = new Attack('4', [], new RandomnessService());
 
     const fakeD20 = sinon.stub();
     fakeD20.onCall(0).returns(3);
@@ -111,7 +112,7 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it handles a nat1 miss correctly', async function (assert) {
-    const attack = new Attack('+20', []);
+    const attack = new Attack('+20', [], new RandomnessService());
 
     const fakeD20 = sinon.stub();
     fakeD20.onCall(0).returns(1);
@@ -136,10 +137,18 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it handles a hit with a constant attack modifier correctly', async function (assert) {
-    const attack = new Attack('5', [
-      new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name),
-      new Damage('2d8', DamageType.RADIANT.name),
-    ]);
+    const attack = new Attack(
+      '5',
+      [
+        new Damage(
+          '2d6 + 5 + 1d4',
+          DamageType.PIERCING.name,
+          new RandomnessService(),
+        ),
+        new Damage('2d8', DamageType.RADIANT.name, new RandomnessService()),
+      ],
+      new RandomnessService(),
+    );
 
     // Fake the results of the d20 attack roll
     const fakeD20 = sinon.stub();
@@ -165,10 +174,18 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it handles a hit with an attack modifier including dice correctly', async function (assert) {
-    const attack = new Attack('5 + 1d4', [
-      new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name),
-      new Damage('2d8', DamageType.RADIANT.name),
-    ]);
+    const attack = new Attack(
+      '5 + 1d4',
+      [
+        new Damage(
+          '2d6 + 5 + 1d4',
+          DamageType.PIERCING.name,
+          new RandomnessService(),
+        ),
+        new Damage('2d8', DamageType.RADIANT.name, new RandomnessService()),
+      ],
+      new RandomnessService(),
+    );
 
     // Fake the results of the d20 attack roll
     const fakeD20 = sinon.stub();
@@ -210,10 +227,18 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it handles a hit with an attack modifier subtracting dice correctly', async function (assert) {
-    const attack = new Attack('5 - 1d6', [
-      new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name),
-      new Damage('2d8', DamageType.RADIANT.name),
-    ]);
+    const attack = new Attack(
+      '5 - 1d6',
+      [
+        new Damage(
+          '2d6 + 5 + 1d4',
+          DamageType.PIERCING.name,
+          new RandomnessService(),
+        ),
+        new Damage('2d8', DamageType.RADIANT.name, new RandomnessService()),
+      ],
+      new RandomnessService(),
+    );
 
     // Fake the results of the d20 attack roll
     const fakeD20 = sinon.stub();
@@ -249,10 +274,18 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it adds damage dice as expected', async function (assert) {
-    const attack = new Attack('5', [
-      new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name),
-      new Damage('2d8', DamageType.RADIANT.name),
-    ]);
+    const attack = new Attack(
+      '5',
+      [
+        new Damage(
+          '2d6 + 5 + 1d4',
+          DamageType.PIERCING.name,
+          new RandomnessService(),
+        ),
+        new Damage('2d8', DamageType.RADIANT.name, new RandomnessService()),
+      ],
+      new RandomnessService(),
+    );
 
     // Fake the results of the d20 attack roll
     const fakeD20 = sinon.stub();
@@ -337,10 +370,18 @@ module('Unit | Utils | attack', function (hooks) {
   });
 
   test('it handles a critical hit as expected', async function (assert) {
-    const attack = new Attack('-5', [
-      new Damage('2d6 + 5 + 1d4', DamageType.PIERCING.name),
-      new Damage('2d8', DamageType.RADIANT.name),
-    ]);
+    const attack = new Attack(
+      '-5',
+      [
+        new Damage(
+          '2d6 + 5 + 1d4',
+          DamageType.PIERCING.name,
+          new RandomnessService(),
+        ),
+        new Damage('2d8', DamageType.RADIANT.name, new RandomnessService()),
+      ],
+      new RandomnessService(),
+    );
 
     // Fake the results of the d20 attack roll
     const fakeD20 = sinon.stub();

--- a/tests/unit/utils/damage-test.ts
+++ b/tests/unit/utils/damage-test.ts
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import DamageType from 'multiattack-5e/components/damage-type-enum';
+import RandomnessService from 'multiattack-5e/services/randomness';
 import Damage from 'multiattack-5e/utils/damage';
 import DiceGroup from 'multiattack-5e/utils/dice-group';
 
@@ -10,7 +11,11 @@ module('Unit | Utils | damage', function (hooks) {
   setupTest(hooks);
 
   test('it rolls one dice', async function (assert) {
-    const damage = new Damage('1d6 + 1', DamageType.RADIANT.name);
+    const damage = new Damage(
+      '1d6 + 1',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,
@@ -41,7 +46,11 @@ module('Unit | Utils | damage', function (hooks) {
   });
 
   test('it rolls and adds multiple dice groups', async function (assert) {
-    const damage = new Damage('3d8 + 1 + 2d6', DamageType.RADIANT.name);
+    const damage = new Damage(
+      '3d8 + 1 + 2d6',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,
@@ -88,7 +97,11 @@ module('Unit | Utils | damage', function (hooks) {
   });
 
   test('it doubles all dice groups on a critical hit', async function (assert) {
-    const damage = new Damage('3d8 + 2 + 2d6', DamageType.RADIANT.name);
+    const damage = new Damage(
+      '3d8 + 2 + 2d6',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,
@@ -140,7 +153,12 @@ module('Unit | Utils | damage', function (hooks) {
   });
 
   test('it does not allow damage to be negative', async function (assert) {
-    const damage = new Damage('1d4 - 3', DamageType.RADIANT.name, true);
+    const damage = new Damage(
+      '1d4 - 3',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+      true,
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,
@@ -172,7 +190,12 @@ module('Unit | Utils | damage', function (hooks) {
   });
 
   test('it halves damage for resistant targets', async function (assert) {
-    const damage = new Damage('2d6 + 1', DamageType.RADIANT.name, true);
+    const damage = new Damage(
+      '2d6 + 1',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+      true,
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,
@@ -204,7 +227,13 @@ module('Unit | Utils | damage', function (hooks) {
   });
 
   test('it doubles damage for vulnerable targets', async function (assert) {
-    const damage = new Damage('2d6 + 1', DamageType.RADIANT.name, false, true);
+    const damage = new Damage(
+      '2d6 + 1',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+      false,
+      true,
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,
@@ -236,7 +265,13 @@ module('Unit | Utils | damage', function (hooks) {
   });
 
   test('it halves, then doubles, damage for resistant and vulnerable targets', async function (assert) {
-    const damage = new Damage('2d6 + 1', DamageType.RADIANT.name, true, true);
+    const damage = new Damage(
+      '2d6 + 1',
+      DamageType.RADIANT.name,
+      new RandomnessService(),
+      true,
+      true,
+    );
 
     assert.strictEqual(
       damage.damage.diceGroups.length,

--- a/tests/unit/utils/dice-group-test.ts
+++ b/tests/unit/utils/dice-group-test.ts
@@ -2,6 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import RandomnessService from 'multiattack-5e/services/randomness';
 import DiceGroup from 'multiattack-5e/utils/dice-group';
 
 module('Unit | Utils | dice-group', function (hooks) {
@@ -9,19 +10,19 @@ module('Unit | Utils | dice-group', function (hooks) {
 
   test('it rejects invalid input values', async function (assert) {
     assert.throws(
-      () => new DiceGroup(-1, 6),
+      () => new DiceGroup(-1, 6, new RandomnessService()),
       new Error('Number of dice in group must be non-negative'),
       'negative number of dice should throw an error',
     );
     assert.throws(
-      () => new DiceGroup(4, -1),
+      () => new DiceGroup(4, -1, new RandomnessService()),
       new Error('Die must have a positive number of sides'),
       'negative number of sides for dice should throw an error',
     );
   });
 
   test('it rolls and totals multiple dice', async function (assert) {
-    const noDice = new DiceGroup(0, 6);
+    const noDice = new DiceGroup(0, 6, new RandomnessService());
     assert.deepEqual(
       noDice.roll(),
       {
@@ -32,7 +33,7 @@ module('Unit | Utils | dice-group', function (hooks) {
     );
 
     // Create a group with a single die and mock its roll
-    const group1d8 = new DiceGroup(1, 8);
+    const group1d8 = new DiceGroup(1, 8, new RandomnessService());
     assert.strictEqual(
       group1d8.numDice,
       1,
@@ -56,7 +57,7 @@ module('Unit | Utils | dice-group', function (hooks) {
     );
 
     // Create a group with multiple dice and mock them
-    const group3d6 = new DiceGroup(3, 6, false);
+    const group3d6 = new DiceGroup(3, 6, new RandomnessService(), false);
     assert.strictEqual(
       group3d6.numDice,
       3,
@@ -91,22 +92,22 @@ module('Unit | Utils | dice-group', function (hooks) {
 
   test('it prints as expected', async function (assert) {
     assert.equal(
-      new DiceGroup(1, 6).prettyString(false),
+      new DiceGroup(1, 6, new RandomnessService()).prettyString(false),
       '1d6',
       'group being added should print as expected',
     );
     assert.equal(
-      new DiceGroup(3, 12, false).prettyString(false),
+      new DiceGroup(3, 12, new RandomnessService(), false).prettyString(false),
       '3d12',
       'whether a group is being subtracted should not affect its printing',
     );
     assert.equal(
-      new DiceGroup(2, 10, false).prettyString(true),
+      new DiceGroup(2, 10, new RandomnessService(), false).prettyString(true),
       '4d10',
       'the number of dice should be doubled when requested',
     );
     assert.equal(
-      new DiceGroup(0, 4, false).prettyString(true),
+      new DiceGroup(0, 4, new RandomnessService(), false).prettyString(true),
       '0d4',
       'zero dice should be handled without errors',
     );

--- a/tests/unit/utils/dice-groups-and-modifier-test.ts
+++ b/tests/unit/utils/dice-groups-and-modifier-test.ts
@@ -2,6 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import RandomnessService from 'multiattack-5e/services/randomness';
 import DiceGroup from 'multiattack-5e/utils/dice-group';
 import DiceGroupsAndModifier from 'multiattack-5e/utils/dice-groups-and-modifier';
 
@@ -10,7 +11,7 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
 
   test('it rolls one dice group', async function (assert) {
     const diceGroupAndModifier = new DiceGroupsAndModifier(
-      [new DiceGroup(1, 6)],
+      [new DiceGroup(1, 6, new RandomnessService())],
       1,
     );
 
@@ -38,7 +39,7 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
 
   test('it rolls double dice when instructed', async function (assert) {
     const diceGroupAndModifier = new DiceGroupsAndModifier(
-      [new DiceGroup(1, 6)],
+      [new DiceGroup(1, 6, new RandomnessService())],
       2,
     );
 
@@ -67,7 +68,10 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
 
   test('it rolls and adds multiple dice groups', async function (assert) {
     const diceGroupAndModifier = new DiceGroupsAndModifier(
-      [new DiceGroup(3, 8), new DiceGroup(2, 6, false)],
+      [
+        new DiceGroup(3, 8, new RandomnessService()),
+        new DiceGroup(2, 6, new RandomnessService(), false),
+      ],
       -3,
     );
 
@@ -111,7 +115,10 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
 
   test('it doubles all dice groups on a critical hit', async function (assert) {
     const diceGroupAndModifier = new DiceGroupsAndModifier(
-      [new DiceGroup(3, 8), new DiceGroup(2, 6)],
+      [
+        new DiceGroup(3, 8, new RandomnessService()),
+        new DiceGroup(2, 6, new RandomnessService()),
+      ],
       2,
     );
 
@@ -161,7 +168,10 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
   test('it prints as expected', async function (assert) {
     assert.equal(
       new DiceGroupsAndModifier(
-        [new DiceGroup(3, 8), new DiceGroup(2, 12)],
+        [
+          new DiceGroup(3, 8, new RandomnessService()),
+          new DiceGroup(2, 12, new RandomnessService()),
+        ],
         2,
       ).prettyString(false),
       '3d8 + 2d12 + 2',
@@ -169,7 +179,10 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
     );
     assert.equal(
       new DiceGroupsAndModifier(
-        [new DiceGroup(3, 8), new DiceGroup(2, 4, false)],
+        [
+          new DiceGroup(3, 8, new RandomnessService()),
+          new DiceGroup(2, 4, new RandomnessService(), false),
+        ],
         -5,
       ).prettyString(false),
       '3d8 - 2d4 - 5',
@@ -191,20 +204,27 @@ module('Unit | Utils | diceGroupAndModifier', function (hooks) {
       '0 modifier should print if there are no accompanying dice groups',
     );
     assert.equal(
-      new DiceGroupsAndModifier([new DiceGroup(1, 4)], 0).prettyString(false),
+      new DiceGroupsAndModifier(
+        [new DiceGroup(1, 4, new RandomnessService())],
+        0,
+      ).prettyString(false),
       '1d4',
       'single dice group should print as expected',
     );
     assert.equal(
-      new DiceGroupsAndModifier([new DiceGroup(1, 4, false)], 0).prettyString(
-        false,
-      ),
+      new DiceGroupsAndModifier(
+        [new DiceGroup(1, 4, new RandomnessService(), false)],
+        0,
+      ).prettyString(false),
       '- 1d4',
       'single negative dice group should print as expected',
     );
     assert.equal(
       new DiceGroupsAndModifier(
-        [new DiceGroup(3, 8), new DiceGroup(2, 4, false)],
+        [
+          new DiceGroup(3, 8, new RandomnessService()),
+          new DiceGroup(2, 4, new RandomnessService(), false),
+        ],
         -5,
       ).prettyString(true),
       '6d8 - 4d4 - 5',

--- a/tests/unit/utils/dice-string-parser-test.ts
+++ b/tests/unit/utils/dice-string-parser-test.ts
@@ -1,6 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import RandomnessService from 'multiattack-5e/services/randomness';
 import DiceGroup from 'multiattack-5e/utils/dice-group';
 import DiceGroupsAndModifier from 'multiattack-5e/utils/dice-groups-and-modifier';
 import DiceStringParser from 'multiattack-5e/utils/dice-string-parser';
@@ -24,7 +25,7 @@ module('Unit | Utils | dice-string-parser', function (hooks) {
 
     for (const invalid of invalidStrings) {
       assert.throws(
-        () => DiceStringParser.parse(invalid),
+        () => DiceStringParser.parse(invalid, new RandomnessService()),
         new Error(
           `Unable to parse dice groups or constants from input string "${invalid}"`,
         ),
@@ -35,23 +36,50 @@ module('Unit | Utils | dice-string-parser', function (hooks) {
 
   test('it parses valid strings', async function (assert) {
     const valid: Map<string, DiceGroupsAndModifier> = new Map();
-    valid.set('1d6+4', new DiceGroupsAndModifier([new DiceGroup(1, 6)], 4));
+    valid.set(
+      '1d6+4',
+      new DiceGroupsAndModifier(
+        [new DiceGroup(1, 6, new RandomnessService())],
+        4,
+      ),
+    );
     valid.set(
       '11d12-10',
-      new DiceGroupsAndModifier([new DiceGroup(11, 12)], -10),
+      new DiceGroupsAndModifier(
+        [new DiceGroup(11, 12, new RandomnessService())],
+        -10,
+      ),
     );
-    valid.set('4d8 + 1', new DiceGroupsAndModifier([new DiceGroup(4, 8)], 1));
+    valid.set(
+      '4d8 + 1',
+      new DiceGroupsAndModifier(
+        [new DiceGroup(4, 8, new RandomnessService())],
+        1,
+      ),
+    );
     valid.set(
       '+3d5-10+1 + 2 - 1D4',
       new DiceGroupsAndModifier(
-        [new DiceGroup(3, 5), new DiceGroup(1, 4, false)],
+        [
+          new DiceGroup(3, 5, new RandomnessService()),
+          new DiceGroup(1, 4, new RandomnessService(), false),
+        ],
         -7,
       ),
     );
-    valid.set('3d5', new DiceGroupsAndModifier([new DiceGroup(3, 5)], 0));
+    valid.set(
+      '3d5',
+      new DiceGroupsAndModifier(
+        [new DiceGroup(3, 5, new RandomnessService())],
+        0,
+      ),
+    );
     valid.set(
       '-2d6   ',
-      new DiceGroupsAndModifier([new DiceGroup(2, 6, false)], 0),
+      new DiceGroupsAndModifier(
+        [new DiceGroup(2, 6, new RandomnessService(), false)],
+        0,
+      ),
     );
     valid.set('40', new DiceGroupsAndModifier([], 40));
     valid.set('-40', new DiceGroupsAndModifier([], -40));
@@ -62,7 +90,7 @@ module('Unit | Utils | dice-string-parser', function (hooks) {
     for (const [dmgStr, expected] of valid) {
       try {
         assert.deepEqual(
-          DiceStringParser.parse(dmgStr),
+          DiceStringParser.parse(dmgStr, new RandomnessService()),
           expected,
           `${dmgStr} should parse to expected value`,
         );

--- a/tests/unit/utils/die-test.ts
+++ b/tests/unit/utils/die-test.ts
@@ -1,6 +1,7 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import RandomnessService from 'multiattack-5e/services/randomness';
 import Die from 'multiattack-5e/utils/die';
 
 module('Unit | Utils | die', function (hooks) {
@@ -8,12 +9,12 @@ module('Unit | Utils | die', function (hooks) {
 
   test('it rejects invalid numbers of sides', async function (assert) {
     assert.throws(
-      () => new Die(-1),
+      () => new Die(-1, new RandomnessService()),
       new Error('Die must have a positive number of sides'),
       'negative number of sides should throw error',
     );
     assert.throws(
-      () => new Die(0),
+      () => new Die(0, new RandomnessService()),
       new Error('Die must have a positive number of sides'),
       'zero sides should throw error',
     );
@@ -22,7 +23,7 @@ module('Unit | Utils | die', function (hooks) {
   test('it rolls dice in the expected range', async function (assert) {
     assert.expect(40);
     for (let sides = 1; sides < 21; sides++) {
-      const die = new Die(sides);
+      const die = new Die(sides, new RandomnessService());
       const roll: number = die.roll();
       assert.true(
         roll >= 1,
@@ -42,7 +43,7 @@ module('Unit | Utils | die', function (hooks) {
     let rolled20 = false;
     let rolled1 = false;
 
-    const die = new Die(20);
+    const die = new Die(20, new RandomnessService());
     for (let i = 0; i < 1000; i++) {
       const roll: number = die.roll();
       if (roll == 20) {


### PR DESCRIPTION
The current acceptance test for the repeated attack form cannot closely examine the detailed display of attack data, since the attack and damage dice are random. This alters the implementation of the die to acquire randomness from a service (which usually uses "Math.random()") which is injected into a component and passed down. A new test then overrides this service to force dice to roll their maximum or minimum values, and makes assertions about the detailed display of attack data. 

Unfortunately, this test also revealed that collapsible panes managed by Bootstrap have some sort of state which persists across tests. After the first rendering test is run, attempts to close the panes fail (although opening the pane still works). A potential solution is to rewrite collapsible behavior to avoid needing Bootstrap's Javascript; for now, though, the tests do not test closing the panes, since I've confirmed manually that this works (and it is unlikely to fail unless there is a problem in Bootstrap's Javascript).