### PR TITLE
Add repeated saving throws

### DIFF
--- a/app/components/damage-pane.hbs
+++ b/app/components/damage-pane.hbs
@@ -1,0 +1,20 @@
+{{#each @damageList as |damage index| }}
+<DamageType data-test-damage-type={{index}} @index={{index}} @setDamage={{damage.setDamage}}
+  @setDamageType={{damage.setDamageType}} @setResistant={{damage.setResistant}}
+  @setVulnerable={{damage.setVulnerable}} @initialDamage={{damage.damageString}}
+  @initialDamageType={{damage.type}} @initialResistant={{damage.targetResistant}}
+  @initialVulnerable={{damage.targetVulnerable}} />
+<div class="row align-items-center">
+  <div class="col-sm">
+    <button data-test-button-remove-damage-type={{index}} class="btn btn-danger my-2" type="button" {{on "click"
+      (fn @removeDamageType index)}}>Remove Damage Type</button>
+  </div>
+</div>
+<hr>
+{{/each}}
+<div class="row align-items-center">
+  <div class="col-sm">
+    <button data-test-button-add-damage-type class="btn btn-info my-3" type="button" {{on "click"
+      @addNewDamageType}}>New Damage Type</button>
+  </div>
+</div>

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -1,58 +1,56 @@
 <div class="row align-items-center justify-content-between">
   <div class="col col-sm-8">
     <h2 data-test-log-header>
-      Attack Log
+      {{@getLogHeader}}
     </h2>
   </div>
   <div class="col col-sm-4 d-flex justify-content-end">
-    <button class="btn btn-danger btn-sm" type="button" {{on "click" @clearAttackLog}}
-      data-test-button-clear-attack-log>
+    <button class="btn btn-danger btn-sm" type="button" {{on "click" @clearLog}}
+      data-test-button-clear-log>
       Clear
     </button>
   </div>
 </div>
 <div class="pt-3">
   <div class="col-scrollable rounded border">
-    <ul class="p-4" data-test-attack-log>
-      {{#each @repeatedAttackLog as |repeatedAttackDetails index|}}
+    <ul class="p-4" data-test-log>
+      {{#each @log as |repeatedSetDetails index|}}
       {{#unless (eq index 0)}}
       <hr>
       <hr>
       <hr>
       {{/unless}}
       <h4 data-test-total-damage-header={{index}}>
-        Total Damage: {{repeatedAttackDetails.totalDmg}} ({{repeatedAttackDetails.totalNumberOfHits}}
-        {{this.getHitString repeatedAttackDetails.totalNumberOfHits}})
+        Total Damage: {{repeatedSetDetails.totalDmg}} ({{ @getSuccessCountString repeatedSetDetails}})
       </h4>
-      <ul data-test-attack-data-list={{index}} class="list-group">
-        <li class="li-no-bullets">Number of attacks: {{repeatedAttackDetails.numberOfAttacks}}</li>
-        <li class="li-no-bullets">Target AC: {{repeatedAttackDetails.targetAC}}</li>
-        <li class="li-no-bullets">Attack roll: {{this.getAttackString repeatedAttackDetails.toHit}}
-          {{#if (eq repeatedAttackDetails.advantageState.name "advantage") }}
+      <ul data-test-data-list={{index}} class="list-group">
+        <li class="li-no-bullets">{{@getRepCountString repeatedSetDetails}}</li>
+        <li class="li-no-bullets">{{@getThresholdString repeatedSetDetails}}</li>
+        <li class="li-no-bullets">{{@getRollString (this.getD20String (@getD20Modifier repeatedSetDetails)) }}
+          {{#if (eq repeatedSetDetails.advantageState.name "advantage") }}
           (advantage)
           {{/if}}
-          {{#if (eq repeatedAttackDetails.advantageState.name "disadvantage") }}
+          {{#if (eq repeatedSetDetails.advantageState.name "disadvantage") }}
           (disadvantage)
           {{/if}}
         </li>
       </ul>
-      <ol data-test-attack-detail-list={{index}}>
-        {{#each repeatedAttackDetails.attackDetailsList as |attackDetails index2|}}
+      <ol data-test-detail-list={{index}}>
+        {{#each repeatedSetDetails.detailsList as |details index2|}}
 
-        {{#if attackDetails.hit }}
-        <li class="li-hit">
-          <span data-test-attack-roll-detail="{{index}}-{{index2}}"
-            title="{{this.getRollDetailString attackDetails.roll.rolls}}">
-            <a data-test-attack-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
-              data-bs-toggle="collapse" href="#attack-detail-collapse-{{index}}-{{index2}}" role="button"
-              aria-expanded="false" aria-controls="attack-detail-collapse-{{index}}-{{index2}}">
-              {{attackDetails.roll.total}}</a> to hit
-            {{#if attackDetails.crit}} (CRIT!){{/if}}
+        {{#if (@isSuccess details) }}
+        <li class="li-success">
+          <span data-test-roll-detail="{{index}}-{{index2}}"
+            title="{{this.getRollDetailString details.roll.rolls}}">
+            <a data-test-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
+              data-bs-toggle="collapse" href="#roll-detail-collapse-{{index}}-{{index2}}" role="button"
+              aria-expanded="false" aria-controls="roll-detail-collapse-{{index}}-{{index2}}">
+              {{details.roll.total}}</a> {{@getD20RollString details}}
           </span>
-          <div data-test-attack-roll-collapse-pane="{{index}}-{{index2}}" class="collapse"
-            id="attack-detail-collapse-{{index}}-{{index2}}">
+          <div data-test-roll-collapse-pane="{{index}}-{{index2}}" class="collapse"
+            id="roll-detail-collapse-{{index}}-{{index2}}">
             <ul>
-              {{#each attackDetails.roll.rolls as |roll|}}
+              {{#each details.roll.rolls as |roll|}}
               <li class="text-muted">
                 {{roll.name}}: {{this.getStringWithSpaces roll.rolls}}
               </li>
@@ -61,7 +59,7 @@
           </div>
 
           <ul data-test-damage-detail-list="{{index}}-{{index2}}">
-            {{#each attackDetails.damageDetails as |damage index3|}}
+            {{#each details.damageDetails as |damage index3|}}
             <li>
               <span data-test-damage-roll-detail="{{index}}-{{index2}}-{{index3}}"
                 title="{{this.getRollDetailString damage.roll.rolls}}">
@@ -75,8 +73,8 @@
                 {{damage.roll.total}}
                 {{/unless}}
                 {{damage.type}} damage
-                {{#if attackDetails.crit}} (<b>{{damage.dice}}</b>){{/if}}
-                {{#unless attackDetails.crit}} ({{damage.dice}}){{/unless}}
+                {{#if (@shouldBoldDice details)}} (<b>{{damage.dice}}</b>){{/if}}
+                {{#unless (@shouldBoldDice details)}} ({{damage.dice}}){{/unless}}
                 {{#if damage.resisted}} (resisted){{/if}}
                 {{#if damage.vulnerable}} (vulnerable){{/if}}
               </span>
@@ -97,20 +95,19 @@
         </li>
         {{/if}}
 
-        {{#unless attackDetails.hit }}
-        <li class="li-miss">
-          <span data-test-attack-roll-detail="{{index}}-{{index2}}"
-            title="{{this.getRollDetailString attackDetails.roll.rolls}}">
-            <a data-test-attack-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
-              data-bs-toggle="collapse" href="#attack-detail-collapse-{{index}}-{{index2}}" role="button"
-              aria-expanded="false" aria-controls="attack-detail-collapse-{{index}}-{{index2}}">
-              {{attackDetails.roll.total}}</a> to hit
-            {{#if attackDetails.nat1}} (NAT 1!){{/if}}
+        {{#unless (@isSuccess details) }}
+        <li class="li-fail">
+          <span data-test-roll-detail="{{index}}-{{index2}}"
+            title="{{this.getRollDetailString details.roll.rolls}}">
+            <a data-test-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
+              data-bs-toggle="collapse" href="#roll-detail-collapse-{{index}}-{{index2}}" role="button"
+              aria-expanded="false" aria-controls="roll-detail-collapse-{{index}}-{{index2}}">
+              {{details.roll.total}}</a> {{@getD20RollString details}}
           </span>
-          <div data-test-attack-roll-collapse-pane="{{index}}-{{index2}}" class="collapse"
-            id="attack-detail-collapse-{{index}}-{{index2}}">
+          <div data-test-roll-collapse-pane="{{index}}-{{index2}}" class="collapse"
+            id="roll-detail-collapse-{{index}}-{{index2}}">
             <ul>
-              {{#each attackDetails.roll.rolls as |roll|}}
+              {{#each details.roll.rolls as |roll|}}
               <li class="text-muted">
                 {{roll.name}}: {{this.getStringWithSpaces roll.rolls}}
               </li>

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -4,7 +4,7 @@ import type { NameAndRolls } from 'multiattack-5e/utils/dice-groups-and-modifier
 
 import AdvantageState from './advantage-state-enum';
 
-export default class kDetailDisplayComponent extends Component {
+export default class DetailDisplayComponent extends Component {
   AdvantageState = AdvantageState;
 
   /**

--- a/app/components/detail-display.ts
+++ b/app/components/detail-display.ts
@@ -4,38 +4,23 @@ import type { NameAndRolls } from 'multiattack-5e/utils/dice-groups-and-modifier
 
 import AdvantageState from './advantage-state-enum';
 
-export default class DetailDisplayComponent extends Component {
+export default class kDetailDisplayComponent extends Component {
   AdvantageState = AdvantageState;
 
   /**
-   * Use the given toHit modifier to represent a 1d20 roll with this modifier.
+   * Use the given modifier to represent a 1d20 roll with this modifier.
    * If the input modifier has no sign at the start of the string, it will be
    * assumed to be positive.
-   * @param toHit a string representing a group of dice and/or numbers added
+   * @param modifier a string representing a group of dice and/or numbers added
    * together
-   * @returns a string representing the toHit string added to 1d20
+   * @returns a string representing the modifier string added to 1d20
    */
-  getAttackString = (toHit: string) => {
-    toHit = toHit.trim();
-    if (toHit.startsWith('+') || toHit.startsWith('-')) {
-      return `1d20 ${toHit}`;
+  getD20String = (modifier: string) => {
+    modifier = modifier.trim();
+    if (modifier.startsWith('+') || modifier.startsWith('-')) {
+      return `1d20 ${modifier}`;
     } else {
-      return `1d20 + ${toHit}`;
-    }
-  };
-
-  /**
-   * Use the given number of hits to return either "hits" or "hit" as
-   * appropriate
-   * @param numberOfHits the number of hits involved
-   * @returns "hit" or "hits" depending on whether numberOfHits is greater than
-   * one
-   */
-  getHitString = (numberOfHits: number) => {
-    if (numberOfHits == 1) {
-      return 'hit';
-    } else {
-      return 'hits';
+      return `1d20 + ${modifier}`;
     }
   };
 

--- a/app/components/main-page.hbs
+++ b/app/components/main-page.hbs
@@ -1,0 +1,39 @@
+<div class="container-reasonable-width">
+  <div class="row align-items-center">
+    <div class="col col-lg-9 pt-5 pb-2">
+      <div class="container-readable-width">
+        <h1>Repeated Attack Simulator</h1>
+        <p>
+          Did a druid just summon a pack of wolves? Has a necromancer gathered a zombie horde? Is a marilith focusing on
+          a single opponent? This tool simulates repeated identical attacks on a single target and displays the total
+          damage alongside a breakdown of the attacks.
+        </p>
+        <p>
+          This uses a 20-sided die for attack rolls, as in D&D 5e and similar systems. If an attack is a critical hit
+          (rolls a 20), the damage dice are rolled twice. Rolling a 1 on the d20 always misses, and a 20 always hits.
+        </p>
+      </div>
+    </div>
+  </div>
+  <nav>
+    <div class="nav nav-tabs" id="nav-tab" role="tablist">
+      <button class="nav-link active" id="nav-attacks-tab" data-bs-toggle="tab" data-bs-target="#nav-attacks"
+        type="button" role="tab" aria-controls="nav-attacks" aria-selected="true">Attacks</button>
+      <button class="nav-link" id="nav-saves-tab" data-bs-toggle="tab" data-bs-target="#nav-saves" type="button"
+        role="tab" aria-controls="nav-saves" aria-selected="false">Saves</button>
+    </div>
+  </nav>
+  <div class="tab-content" id="nav-tabContent">
+    <div class="tab-pane fade show active" id="nav-attacks" role="tabpanel" aria-labelledby="nav-attacks-tab"
+      tabindex="0">
+      <div class="py-3">
+        <RepeatedAttackForm />
+      </div>
+    </div>
+    <div class="tab-pane fade" id="nav-saves" role="tabpanel" aria-labelledby="nav-saves-tab" tabindex="0">
+      <div class="py-3">
+        <RepeatedSaveForm />
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/main-page.hbs
+++ b/app/components/main-page.hbs
@@ -17,9 +17,9 @@
   </div>
   <nav>
     <div class="nav nav-tabs" id="nav-tab" role="tablist">
-      <button class="nav-link active" id="nav-attacks-tab" data-bs-toggle="tab" data-bs-target="#nav-attacks"
+      <button data-test-button-attackTab class="nav-link active" id="nav-attacks-tab" data-bs-toggle="tab" data-bs-target="#nav-attacks"
         type="button" role="tab" aria-controls="nav-attacks" aria-selected="true">Attacks</button>
-      <button class="nav-link" id="nav-saves-tab" data-bs-toggle="tab" data-bs-target="#nav-saves" type="button"
+      <button data-test-button-saveTab class="nav-link" id="nav-saves-tab" data-bs-toggle="tab" data-bs-target="#nav-saves" type="button"
         role="tab" aria-controls="nav-saves" aria-selected="false">Saves</button>
     </div>
   </nav>

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -3,7 +3,7 @@
     <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
       <h2>Set Up Attacks</h2>
       <div class="row align-items-center py-2">
-        <label for="numberOfAttacks" class="col-6 col-form-label">Number of Attacks</label>
+        <label data-test-attack-form-label for="numberOfAttacks" class="col-6 col-form-label">Number of Attacks</label>
         <div class="col-6">
           <Input data-test-input-numberOfAttacks class="form-control" id="numberOfAttacks" name="numberOfAttacks"
             @type="number" @value={{this.numberOfAttacks}} min="0" title="Number of attacks cannot be negative"

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -1,94 +1,61 @@
-<div class="container-reasonable-width">
-  <div class="row align-items-center">
-    <div class="col col-lg-9 pt-5 pb-4">
-      <div class="container-readable-width">
-        <h1>Repeated Attack Simulator</h1>
-        <p>
-          Did a druid just summon a pack of wolves? Has a necromancer gathered a zombie horde? Is a marilith focusing on
-          a single opponent? This tool simulates repeated identical attacks on a single target and displays the total
-          damage alongside a breakdown of the attacks.
-        </p>
-        <p>
-          This uses a 20-sided die for attack rolls, as in D&D 5e and similar systems. If an attack is a critical hit
-          (rolls a 20), the damage dice are rolled twice. Rolling a 1 on the d20 always misses, and a 20 always hits.
-        </p>
+<div class="row align-items-top justify-content-between">
+  <div class="col-md-4">
+    <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
+      <h2>Set Up Attacks</h2>
+      <div class="row align-items-center py-2">
+        <label for="numberOfAttacks" class="col-6 col-form-label">Number of Attacks</label>
+        <div class="col-6">
+          <Input data-test-input-numberOfAttacks class="form-control" id="numberOfAttacks" name="numberOfAttacks"
+            @type="number" @value={{this.numberOfAttacks}} min="0" title="Number of attacks cannot be negative"
+            required="required" />
+        </div>
       </div>
-    </div>
+
+      <div class="row align-items-center py-2">
+        <label for="targetAC" class="col-6 col-form-label">Target AC</label>
+        <div class="col-6">
+          <Input data-test-input-targetAC class="form-control" id="targetAC" name="targetAC" @type="number"
+            @value={{this.targetAC}} required="required" />
+        </div>
+      </div>
+
+      <div class="row align-items-center py-2">
+        <label for="toHit" class="col-6 col-form-label">To Hit Modifier</label>
+        <div class="col-6">
+          <div class="input-group">
+            <div class="input-group-text">1d20 +</div>
+            <Input data-test-input-toHit class="form-control" @type="text" id="toHit" name="toHit" @value={{this.toHit}}
+              aria-describedby="toHitDescription" required="required" pattern={{this.diceGroupsRegex}}
+              title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
+          </div>
+        </div>
+      </div>
+
+      <div class="row align-items-center py-2">
+        <label class="col-6 col-form-label">Rolls With</label>
+        <div class="col-6">
+          <AdvantageRadio @updateState={{this.setAdvantageState}} />
+        </div>
+      </div>
+
+      <hr>
+
+      <DamagePane @damageList={{this.damageList}} @removeDamageType={{this.removeDamageType}}
+        @addNewDamageType={{this.addNewDamageType}} />
+
+      <div class="row align-items-center mx-auto mb-5">
+        <button data-test-button-getDamage class="btn btn-primary btn-lg w-70 d-block" type="submit" id="attackBtn"
+          {{on "click" this.simulateRepeatedAttacks}}>Attack!</button>
+      </div>
+    </form>
   </div>
-  <div class="row align-items-top justify-content-between">
-    <div class="col-md-4">
-      <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
-        <h2>Set Up Attacks</h2>
-        <div class="row align-items-center py-2">
-          <label for="numberOfAttacks" class="col-6 col-form-label">Number of Attacks</label>
-          <div class="col-6">
-            <Input data-test-input-numberOfAttacks class="form-control" id="numberOfAttacks" name="numberOfAttacks"
-              @type="number" @value={{this.numberOfAttacks}} min="0" title="Number of attacks cannot be negative"
-              required="required" />
-          </div>
-        </div>
 
-        <div class="row align-items-center py-2">
-          <label for="targetAC" class="col-6 col-form-label">Target AC</label>
-          <div class="col-6">
-            <Input data-test-input-targetAC class="form-control" id="targetAC" name="targetAC" @type="number"
-              @value={{this.targetAC}} required="required" />
-          </div>
-        </div>
-
-        <div class="row align-items-center py-2">
-          <label for="toHit" class="col-6 col-form-label">To Hit Modifier</label>
-          <div class="col-6">
-            <div class="input-group">
-              <div class="input-group-text">1d20 +</div>
-              <Input data-test-input-toHit class="form-control" @type="text" id="toHit" name="toHit"
-                @value={{this.toHit}} aria-describedby="toHitDescription" required="required"
-                pattern={{this.diceGroupsRegex}}
-                title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
-            </div>
-          </div>
-        </div>
-
-        <div class="row align-items-center py-2">
-          <label class="col-6 col-form-label">Rolls With</label>
-          <div class="col-6">
-            <AdvantageRadio @updateState={{this.setAdvantageState}} />
-          </div>
-        </div>
-
-        <hr>
-
-
-        {{#each this.damageList as |damage index| }}
-        <DamageType data-test-damage-type={{index}} @index={{index}} @setDamage={{damage.setDamage}}
-          @setDamageType={{damage.setDamageType}} @setResistant={{damage.setResistant}}
-          @setVulnerable={{damage.setVulnerable}} @initialDamage={{damage.damageString}}
-          @initialDamageType={{damage.type}} @initialResistant={{damage.targetResistant}}
-          @initialVulnerable={{damage.targetVulnerable}} />
-        <div class="row align-items-center">
-          <div class="col-sm">
-            <button data-test-button-remove-damage-type={{index}} class="btn btn-danger my-2" type="button" {{on "click"
-              (fn this.removeDamageType index)}}>Remove Damage Type</button>
-          </div>
-        </div>
-        <hr>
-        {{/each}}
-        <div class="row align-items-center">
-          <div class="col-sm">
-            <button data-test-button-add-damage-type class="btn btn-info my-3" type="button" {{on "click"
-              this.addNewDamageType}}>New Damage Type</button>
-          </div>
-        </div>
-
-        <div class="row align-items-center mx-auto mb-5">
-          <button data-test-button-getDamage class="btn btn-primary btn-lg w-70 d-block" type="submit" id="attackBtn"
-            {{on "click" this.simulateRepeatedAttacks}}>Attack!</button>
-        </div>
-      </form>
-    </div>
-
-    <div class="col-md-7">
-      <DetailDisplay @repeatedAttackLog={{this.attackResultLog}} @clearAttackLog={{this.clearAttackLog}} />
-    </div>
+  <div class="col-md-7">
+    <DetailDisplay @log={{this.attackResultLog}} @clearLog={{this.clearAttackLog}} @getLogHeader={{this.getLogHeader}}
+      @getSuccessCountString={{this.getHitCountString}} @getRepCountString={{this.getAttackCountString}}
+      @getThresholdString={{this.getTargetACString}} @getD20Modifier={{this.getToHitModifier}}
+      @getRollString={{this.getAttackRollString}} @isSuccess={{this.isHit}}
+      @getD20RollString={{this.getD20RollString}}
+      @shouldBoldDice={{this.shouldBoldDice}} />
   </div>
 </div>

--- a/app/components/repeated-attack-form.ts
+++ b/app/components/repeated-attack-form.ts
@@ -91,6 +91,64 @@ export default class RepeatedAttackFormComponent extends Component {
     return new Damage('2d6 + 3', DamageType.PIERCING.name, this.randomness);
   }
 
+  /**
+   * Customize the attack detail log
+   * @returns the desired header for the attack detail log
+   */
+  getLogHeader = () => {
+    return 'Attack Log';
+  };
+
+  /**
+   * Use the attack's number of hits to return either "N hits" or "1 hit" as
+   * appropriate
+   * @param repeatedAttack the result of a repeated set of attacks, which
+   * specifies the total number of hits in the set of attacks
+   * @returns "1 hit" or "numberOfHits hits" depending on whether the number of
+   * hits in the input data is one.
+   */
+  getHitCountString = (repeatedAttack: RepeatedAttackResult) => {
+    if (repeatedAttack.totalNumberOfHits == 1) {
+      return `${repeatedAttack.totalNumberOfHits} hit`;
+    } else {
+      return `${repeatedAttack.totalNumberOfHits} hits`;
+    }
+  };
+
+  getAttackCountString = (repeatedAttack: RepeatedAttackResult) => {
+    return `Number of attacks: ${repeatedAttack.numberOfAttacks}`;
+  };
+
+  getTargetACString = (repeatedAttack: RepeatedAttackResult) => {
+    return `Target AC: ${repeatedAttack.targetAC}`;
+  };
+
+  getToHitModifier = (repeatedAttack: RepeatedAttackResult) => {
+    return repeatedAttack.toHit;
+  };
+
+  getAttackRollString = (toHitString: string) => {
+    return `Attack roll: ${toHitString}`;
+  };
+
+  getD20RollString = (attack: AttackDetails) => {
+    if (attack.crit) {
+      return `to hit (CRIT!)`;
+    }
+    if (attack.nat1) {
+      return `to hit (NAT 1!)`;
+    }
+    return `to hit`;
+  };
+
+  shouldBoldDice = (attack: AttackDetails) => {
+    return attack.crit;
+  };
+
+  isHit = (attack: AttackDetails) => {
+    return attack.hit;
+  };
+
   simulateRepeatedAttacks = () => {
     if (!this.randomness) {
       throw new Error(

--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -55,7 +55,7 @@
     <DetailDisplay @log={{this.saveResultLog}} @clearLog={{this.clearSaveLog}} @getLogHeader={{this.getLogHeader}}
       @getSuccessCountString={{this.getPassCountString}} @getRepCountString={{this.getSaveCountString}}
       @getThresholdString={{this.getSaveDCString}} @getD20Modifier={{this.getSaveModifier}}
-      @getRollString={{this.getSavingThrowString}} @isSuccess={{this.isPass}} @getD20RollString={{this.getSaveString}}
+      @getRollString={{this.getSavingThrowString}} @isSuccess={{this.isPass}} @getD20RollString={{this.getD20RollString}}
       @shouldBoldDice={{this.shouldBoldDice}} />
   </div>
 </div>

--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -1,0 +1,61 @@
+<div class="row align-items-top justify-content-between">
+  <div class="col-md-4">
+    <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
+      <h2>Set Up Saves</h2>
+      <div class="row align-items-center py-2">
+        <label for="numberOfSaves" class="col-6 col-form-label">Number of Saves</label>
+        <div class="col-6">
+          <Input data-test-input-numberOfSaves class="form-control" id="numberOfSaves" name="numberOfSaves"
+            @type="number" @value={{this.numberOfSaves}} min="0" title="Number of saves cannot be negative"
+            required="required" />
+        </div>
+      </div>
+
+      <div class="row align-items-center py-2">
+        <label for="saveDC" class="col-6 col-form-label">Save DC</label>
+        <div class="col-6">
+          <Input data-test-input-saveDC class="form-control" id="saveDC" name="saveDC" @type="number"
+            @value={{this.saveDC}} required="required" />
+        </div>
+      </div>
+
+      <div class="row align-items-center py-2">
+        <label for="saveMod" class="col-6 col-form-label">Save Modifier</label>
+        <div class="col-6">
+          <div class="input-group">
+            <div class="input-group-text">1d20 +</div>
+            <Input data-test-input-saveMod class="form-control" @type="text" id="saveMod" name="saveMod"
+              @value={{this.saveMod}} aria-describedby="saveModDescription" required="required"
+              pattern={{this.diceGroupsRegex}}
+              title="Modifier must be dice groups and/or numbers added and subtracted, like '-5 + 1d4' or '7' or '1d4 - 1d6 + 2'" />
+          </div>
+        </div>
+      </div>
+
+      <div class="row align-items-center py-2">
+        <label class="col-6 col-form-label">Rolls With</label>
+        <div class="col-6">
+          <AdvantageRadio @updateState={{this.setAdvantageState}} />
+        </div>
+      </div>
+
+      <hr>
+
+      <DamagePane @damageList={{this.damageList}} @removeDamageType={{this.removeDamageType}}
+        @addNewDamageType={{this.addNewDamageType}} />
+
+      <div class="row align-items-center mx-auto mb-5">
+        <button data-test-button-simulateSaves class="btn btn-primary btn-lg w-70 d-block" type="submit" id="saveBtn"
+          {{on "click" this.simulateRepeatedSaves}}>Roll Saves!</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="col-md-7">
+    <DetailDisplay @log={{this.saveResultLog}} @clearLog={{this.clearSaveLog}} @getLogHeader={{this.getLogHeader}}
+      @getSuccessCountString={{this.getPassCountString}} @getRepCountString={{this.getSaveCountString}}
+      @getThresholdString={{this.getSaveDCString}} @getD20Modifier={{this.getSaveModifier}}
+      @getRollString={{this.getSavingThrowString}} @isSuccess={{this.isPass}} @getD20RollString={{this.getSaveString}}
+      @shouldBoldDice={{this.shouldBoldDice}} />
+  </div>
+</div>

--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -3,7 +3,7 @@
     <form class="needs-validation" onsubmit={{this.suppressPageRefresh}}>
       <h2>Set Up Saves</h2>
       <div class="row align-items-center py-2">
-        <label for="numberOfSaves" class="col-6 col-form-label">Number of Saves</label>
+        <label data-test-save-form-label for="numberOfSaves" class="col-6 col-form-label">Number of Saves</label>
         <div class="col-6">
           <Input data-test-input-numberOfSaves class="form-control" id="numberOfSaves" name="numberOfSaves"
             @type="number" @value={{this.numberOfSaves}} min="0" title="Number of saves cannot be negative"
@@ -45,7 +45,7 @@
         @addNewDamageType={{this.addNewDamageType}} />
 
       <div class="row align-items-center mx-auto mb-5">
-        <button data-test-button-simulateSaves class="btn btn-primary btn-lg w-70 d-block" type="submit" id="saveBtn"
+        <button data-test-button-rollSaves class="btn btn-primary btn-lg w-70 d-block" type="submit" id="saveBtn"
           {{on "click" this.simulateRepeatedSaves}}>Roll Saves!</button>
       </div>
     </form>

--- a/app/components/repeated-save-form.ts
+++ b/app/components/repeated-save-form.ts
@@ -136,7 +136,7 @@ export default class RepeatedSaveFormComponent extends Component {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getSaveRollString = (ignored: SaveDetails) => {
+  getD20RollString = (ignored: SaveDetails) => {
     return 'to save';
   };
 

--- a/app/components/repeated-save-form.ts
+++ b/app/components/repeated-save-form.ts
@@ -1,0 +1,178 @@
+import { A } from '@ember/array';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import type { EmptyObject } from '@glimmer/component/-private/component';
+import { tracked } from '@glimmer/tracking';
+
+import type RandomnessService from 'multiattack-5e/services/randomness';
+import Damage from 'multiattack-5e/utils/damage';
+import DiceStringParser from 'multiattack-5e/utils/dice-string-parser';
+import type {
+  RepeatedSaveResult,
+  SaveDetails,
+} from 'multiattack-5e/utils/repeated-save';
+import RepeatedSave from 'multiattack-5e/utils/repeated-save';
+
+import AdvantageState from './advantage-state-enum';
+import DamageType from './damage-type-enum';
+
+export default class RepeatedSaveFormComponent extends Component {
+  @service('randomness') randomness: RandomnessService | undefined;
+
+  @tracked numberOfSaves = 5;
+  @tracked saveDC = 15;
+
+  @tracked saveMod = '5 + 1d4';
+
+  @tracked rollDamageEverySave = false;
+  @tracked saveForHalfDamage = false;
+  @tracked damageList: Damage[] = A([this.getDefaultDamage()]);
+
+  @tracked advantageState = AdvantageState.STRAIGHT;
+
+  @tracked totalDmg = 0;
+  @tracked totalPasses = 0;
+  @tracked saveDetailsList: SaveDetails[] = [];
+
+  @tracked saveResultLog: RepeatedSaveResult[];
+
+  diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
+
+  /**
+   * Set up an save with default values and load the save result log if
+   * available
+   */
+  constructor(owner: unknown, args: EmptyObject) {
+    super(owner, args);
+    // TODO: Try to retrieve a stored save log
+    this.saveResultLog = [];
+  }
+
+  /**
+   * This function is used to stop the repeated-save-form handlebars from
+   * refreshing the page whenever the form is submitted. Without this, the tests
+   * which use form submission enter an infinite loop.
+   * @returns false
+   */
+  @action
+  suppressPageRefresh() {
+    return false;
+  }
+
+  @action
+  setAdvantageState(newState: AdvantageState) {
+    assert(
+      'advantage state handler must receive an advantage state',
+      newState instanceof AdvantageState,
+    );
+    this.advantageState = newState;
+  }
+
+  @action
+  addNewDamageType() {
+    this.damageList.pushObject(this.getDefaultDamage());
+  }
+
+  @action
+  removeDamageType(index: number) {
+    this.damageList.removeAt(index);
+  }
+
+  @action
+  clearSaveLog() {
+    // TODO: Clear the log from storage as well as in memory
+    this.saveResultLog = [];
+  }
+
+  getDefaultDamage(): Damage {
+    if (!this.randomness) {
+      throw new Error(
+        'Unable to access randomness service; service injection failed?',
+      );
+    }
+    return new Damage('8d6', DamageType.FIRE.name, this.randomness);
+  }
+
+  /**
+   * Customize the save detail log
+   * @returns the desired header for the save detail log
+   */
+  getLogHeader = () => {
+    return 'Save Log';
+  };
+
+  /**
+   * Use the save's's number of passes to return either "N passes" or "1 pass"
+   * as appropriate
+   * @param repeatedSave data for a set of repeated saves, which includes the
+   * total number of saves passed
+   * @returns "1 pass" or "numberOfPasses passes" depending on whether
+   * the total number of passes is equal to 1
+   */
+  getPassCountString = (repeatedSave: RepeatedSaveResult) => {
+    if (repeatedSave.totalNumberOfPasses == 1) {
+      return `${repeatedSave.totalNumberOfPasses} pass`;
+    } else {
+      return `${repeatedSave.totalNumberOfPasses} passes`;
+    }
+  };
+
+  getSaveCountString = (repeatedSave: RepeatedSaveResult) => {
+    return `Number of saves: ${repeatedSave.numberOfSaves}`;
+  };
+
+  getSaveDCString = (repeatedSave: RepeatedSaveResult) => {
+    return `Save DC: ${repeatedSave.saveDC}`;
+  };
+
+  getSaveModifier = (repeatedSave: RepeatedSaveResult) => {
+    return repeatedSave.modifier;
+  };
+
+  getSavingThrowString = (saveString: string) => {
+    return `Saving throw: ${saveString}`;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getSaveRollString = (ignored: SaveDetails) => {
+    return 'to save';
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  shouldBoldDice = (ignored: SaveDetails) => {
+    return false;
+  };
+
+  isPass = (save: SaveDetails) => {
+    return save.pass;
+  };
+
+  simulateRepeatedSaves = () => {
+    if (!this.randomness) {
+      throw new Error(
+        'Unable to access randomness service; service injection failed?',
+      );
+    }
+
+    const nextRepeatedSave = new RepeatedSave(
+      this.numberOfSaves,
+      this.saveDC,
+      this.saveMod,
+      this.advantageState,
+      this.randomness,
+      this.rollDamageEverySave,
+      this.saveForHalfDamage,
+      this.damageList,
+    );
+
+    // Create a new array so that the page will re-render
+    this.saveResultLog = [
+      nextRepeatedSave.simulateRepeatedSaves(),
+      ...this.saveResultLog,
+    ];
+
+    // TODO: Attempt to store the updated save log
+  };
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,19 +1,19 @@
 /* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
 
-.li-hit {
+.li-success {
   padding-inline-start: 1ch;
 }
 
-.li-hit::marker {
+.li-success::marker {
   color: green;
   content: "✓";
 }
 
-.li-miss {
+.li-fail {
   padding-inline-start: 1ch;
 }
 
-.li-miss::marker {
+.li-fail::marker {
   color: red;
   content: "✕";
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -9,7 +9,7 @@
 
 <div class="container">
   <Header />
-  <RepeatedAttackForm />
+  <MainPage />
   <Footer />
 </div>
 

--- a/app/utils/repeated-attack.ts
+++ b/app/utils/repeated-attack.ts
@@ -15,7 +15,7 @@ export interface RepeatedAttackResult {
   // the results of executing the repeated attacks
   totalDmg: number;
   totalNumberOfHits: number;
-  attackDetailsList: AttackDetails[];
+  detailsList: AttackDetails[];
 }
 
 export default class RepeatedAttack {
@@ -111,7 +111,7 @@ export default class RepeatedAttack {
 
       totalDmg: totalDmg,
       totalNumberOfHits: totalNumberOfHits,
-      attackDetailsList: attackDetailsList,
+      detailsList: attackDetailsList,
     };
   }
 }

--- a/app/utils/repeated-save.ts
+++ b/app/utils/repeated-save.ts
@@ -16,7 +16,7 @@ export interface RepeatedSaveResult {
   // the results of executing the repeated saves
   totalDmg: number;
   totalNumberOfPasses: number;
-  saveDetailsList: SaveDetails[];
+  detailsList: SaveDetails[];
 }
 
 export interface SaveDetails {
@@ -152,7 +152,7 @@ export default class RepeatedSave {
 
       totalDmg: totalDamage,
       totalNumberOfPasses: totalNumberOfPasses,
-      saveDetailsList: saveDetailsList,
+      detailsList: saveDetailsList,
     };
   }
 }

--- a/tests/acceptance/main-page-test.ts
+++ b/tests/acceptance/main-page-test.ts
@@ -1,0 +1,147 @@
+import { click, currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import type { ElementContext } from '../types/element-context';
+
+module('Acceptance | main page', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /', async function (assert) {
+    await visit('/');
+
+    assert.strictEqual(
+      currentURL(),
+      '/',
+      'should have navigated to the root url',
+    );
+
+    // Check for the expected header
+    assert
+      .dom('h1')
+      .hasText('Repeated Attack Simulator', 'page title should be displayed');
+
+    // Check that the attack form is set as the default
+    assert
+      .dom('[data-test-attack-form-label]')
+      .isVisible('attack setup heading should be displayed');
+    assert
+      .dom('[data-test-log-header]')
+      .hasText('Attack Log', 'attack log heading should be displayed');
+  });
+
+  test('switching between tabs', async function (assert) {
+    await visit('/');
+
+    // The initial tab should be the attack form
+    assert
+      .dom('#nav-attacks [data-test-attack-form-label]')
+      .isVisible('attack form label should be displayed');
+    assert
+      .dom('[data-test-save-form-label]')
+      .isNotVisible('save form label should not be displayed');
+
+    // Switch to the form for saves
+    await click('[data-test-button-saveTab]');
+    assert
+      .dom('[data-test-attack-form-label]')
+      .isNotVisible('attack form label should not be displayed');
+    assert
+      .dom('[data-test-save-form-label]')
+      .isVisible('save form label should be displayed');
+
+    // Switch back to the form for attacks
+    await click('[data-test-button-attackTab]');
+    assert
+      .dom('[data-test-attack-form-label]')
+      .isVisible('attack form label should be displayed');
+    assert
+      .dom('[data-test-save-form-label]')
+      .isNotVisible('save form label should not be displayed');
+  });
+
+  test('it retains the state of each tab when switched away', async function (this: ElementContext, assert) {
+    await visit('/');
+
+    // The main page should begin on the attack form
+    assert
+      .dom('[data-test-attack-form-label]')
+      .isVisible('attack form label should be displayed');
+
+    // Trigger two attacks (with the default configuration)
+    await click('[data-test-button-getDamage]');
+    await click('[data-test-button-getDamage]');
+
+    // Check and save the first damage header
+    assert
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
+      .isVisible('data from the first set of attacks should be displayed')
+      .containsText(
+        'Total Damage',
+        'the damage header should match expectations',
+      );
+    const firstAttackDamageHeader = this.element.querySelector(
+      '#nav-attacks [data-test-total-damage-header="0"]',
+    )!.textContent!;
+
+    // Check and save the second damage header
+    assert
+      .dom('#nav-attacks [data-test-total-damage-header="1"]')
+      .isVisible('data from the second set of attacks should be displayed')
+      .containsText(
+        'Total Damage',
+        'the damage header should match expectations',
+      );
+    const secondAttackDamageHeader = this.element.querySelector(
+      '#nav-attacks [data-test-total-damage-header="1"]',
+    )!.textContent!;
+
+    // Switch to the form for saves
+    await click('[data-test-button-saveTab]');
+    assert
+      .dom('[data-test-save-form-label]')
+      .isVisible('save form label should be displayed');
+
+    // Trigger one save
+    await click('[data-test-button-rollSaves]');
+
+    // One set of saves should be displayed in the detail pane
+    // Check and save the first damage header
+    assert
+      .dom('#nav-saves [data-test-total-damage-header="0"]')
+      .isVisible('data from the first set of saves should be displayed')
+      .containsText(
+        'Total Damage',
+        'the damage header should match expectations',
+      );
+    const firstSaveDamageHeader = this.element.querySelector(
+      '#nav-saves [data-test-total-damage-header="0"]',
+    )!.textContent!;
+
+    assert.notEqual(
+      firstAttackDamageHeader,
+      firstSaveDamageHeader,
+      'attack damage and save damage headers should not match',
+    );
+
+    // Switch back to the form for attacks
+    await click('[data-test-button-attackTab]');
+    assert
+      .dom('[data-test-attack-form-label]')
+      .isVisible('attack form label should be displayed');
+
+    // Two sets of attacks should still be displayed in the detail pane
+    assert
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
+      .hasText(
+        firstAttackDamageHeader,
+        'first attack damage header should still be present',
+      );
+    assert
+      .dom('#nav-attacks [data-test-total-damage-header="1"]')
+      .hasText(
+        secondAttackDamageHeader,
+        'second attack damage header should still be present',
+      );
+  });
+});

--- a/tests/acceptance/main-page-test.ts
+++ b/tests/acceptance/main-page-test.ts
@@ -26,7 +26,7 @@ module('Acceptance | main page', function (hooks) {
       .dom('[data-test-attack-form-label]')
       .isVisible('attack setup heading should be displayed');
     assert
-      .dom('[data-test-log-header]')
+      .dom('#nav-attacks [data-test-log-header]')
       .hasText('Attack Log', 'attack log heading should be displayed');
   });
 

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -19,103 +19,87 @@ module('Acceptance | repeated attack form', function (hooks) {
     );
 
     assert
-      .dom('h2')
-      .hasText('Set Up Attacks', 'attack setup heading should be displayed');
+      .dom('#nav-attacks [data-test-attack-form-label]')
+      .isVisible('attack setup heading should be displayed');
     assert
-      .dom('[data-test-log-header]')
+      .dom('#nav-attacks [data-test-log-header]')
       .hasText('Attack Log', 'attack log heading should be displayed');
   });
 
-  test('performing single attack', async function (this: ElementContext, assert) {
+  test('performing single set of attacks', async function (this: ElementContext, assert) {
     await visit('/');
 
     // Fill in some details for the attack
-    await fillIn('[data-test-input-numberOfAttacks]', '8');
-    await fillIn('[data-test-input-targetAC]', '15');
-    await fillIn('[data-test-input-toHit]', '3 - 1D6');
-    await fillIn('[data-test-input-damage="0"]', '2d6 + 5');
-    await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
-    await click('[data-test-value="advantage"]');
-    await click('[data-test-value="disadvantage"]');
-    await click('[data-test-input-resistant="0"]');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '8');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '15');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3 - 1D6');
+    await fillIn('#nav-attacks [data-test-input-damage="0"]', '2d6 + 5');
+    await select(
+      '#nav-attacks [data-test-damage-dropdown="0"]',
+      DamageType.RADIANT.name,
+    );
+    await click('#nav-attacks [data-test-value="advantage"]');
+    await click('#nav-attacks [data-test-value="disadvantage"]');
+    await click('#nav-attacks [data-test-input-resistant="0"]');
 
     assert
-      .dom('[data-test-plan-detail-list="0"]')
-      .isNotVisible(
-        'attack details should not be displayed before the attack is requested',
-      );
-
-    assert
-      .dom('[data-test-total-damage-header="0"]')
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
       .isNotVisible(
         'damage header should not be displayed before the attack has been requested',
       );
 
-    assert
-      .dom('[data-test-detail-list="0"]')
-      .isNotVisible(
-        'attack detail list should not be displayed before the attack has been requested',
-      );
-
     // Calculate the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 8\n' +
           'Target AC: 15\n' +
           'Attack roll: 1d20 - 1d6 + 3 (disadvantage)\n',
-        'the details for the input damage should be displayed',
+        'the details for the set of attacks should be displayed',
       );
 
     assert
-      .dom('[data-test-total-damage-header="0"]')
-      .isVisible('damage header should be displayed');
-
-    assert
-      .dom('[data-test-total-damage-header="0"]')
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
+      .isVisible('damage header should be displayed')
       .hasTextContaining('Total Damage');
 
     assert
-      .dom('[data-test-detail-list="0"]')
-      .isVisible('attack details should be displayed');
+      .dom('#nav-attacks [data-test-detail-list="0"]')
+      .isVisible('individual attack details should be displayed');
 
     assert.equal(
-      this.element.querySelector('[data-test-detail-list="0"]')?.children
-        .length,
+      this.element.querySelector('#nav-attacks [data-test-detail-list="0"]')!
+        .children.length,
       8,
       '8 attacks should have been displayed',
     );
   });
 
-  test('performing repeated attacks', async function (this: ElementContext, assert) {
+  test('performing repeated sets of attacks', async function (this: ElementContext, assert) {
     await visit('/');
 
     // Fill in some details for the attack
-    await fillIn('[data-test-input-numberOfAttacks]', '8');
-    await fillIn('[data-test-input-targetAC]', '15');
-    await fillIn('[data-test-input-toHit]', '3 - 1D6');
-    await fillIn('[data-test-input-damage="0"]', '2d6 + 5');
-    await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
-    await click('[data-test-value="advantage"]');
-    await click('[data-test-value="disadvantage"]');
-    await click('[data-test-input-resistant="0"]');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '8');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '15');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3 - 1D6');
+    await click('#nav-attacks [data-test-value="disadvantage"]');
 
     // Calculate the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     // Change some attack details
-    await fillIn('[data-test-input-numberOfAttacks]', '4');
-    await click('[data-test-value="advantage"]');
-    await fillIn('[data-test-input-toHit]', '3');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '4');
+    await click('#nav-attacks [data-test-value="advantage"]');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3');
 
     // Attack again
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     // The second attack should be displayed first
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 4\n' +
           'Target AC: 15\n' +
@@ -124,19 +108,19 @@ module('Acceptance | repeated attack form', function (hooks) {
       );
 
     assert
-      .dom('[data-test-detail-list="0"]')
+      .dom('#nav-attacks [data-test-detail-list="0"]')
       .isVisible('attack details should be displayed for the second attack');
 
     assert.equal(
-      this.element.querySelector('[data-test-detail-list="0"]')?.children
-        .length,
+      this.element.querySelector('#nav-attacks [data-test-detail-list="0"]')!
+        .children.length,
       4,
       '4 attacks should have been displayed for the second set of attacks',
     );
 
     // The first repeated attack should still be visible
     assert
-      .dom('[data-test-data-list="1"]')
+      .dom('#nav-attacks [data-test-data-list="1"]')
       .hasText(
         'Number of attacks: 8\n' +
           'Target AC: 15\n' +
@@ -145,12 +129,12 @@ module('Acceptance | repeated attack form', function (hooks) {
       );
 
     assert
-      .dom('[data-test-detail-list="1"]')
+      .dom('#nav-attacks [data-test-detail-list="1"]')
       .isVisible('attack details should be displayed for the first attack');
 
     assert.equal(
-      this.element.querySelector('[data-test-detail-list="1"]')?.children
-        .length,
+      this.element.querySelector('#nav-attacks [data-test-detail-list="1"]')!
+        .children.length,
       8,
       '8 attacks should have been displayed for the first set of attacks',
     );
@@ -161,115 +145,118 @@ module('Acceptance | repeated attack form', function (hooks) {
 
     // Initially, there should be one damage type displayed
     assert
-      .dom('[data-test-input-damage="0"]')
+      .dom('#nav-attacks [data-test-input-damage="0"]')
       .exists('one damage type should exist');
     assert
-      .dom('[data-test-input-damage="1"]')
+      .dom('#nav-attacks [data-test-input-damage="1"]')
       .doesNotExist('only one damage type should exist');
     assert
-      .dom('[data-test-damage-dropdown="0"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="0"]')
       .hasValue(
         DamageType.PIERCING.name,
         'damage 0 should be piercing (by default)',
       );
 
     // Add another damage type
-    await click('[data-test-button-add-damage-type]');
+    await click('#nav-attacks [data-test-button-add-damage-type]');
 
     assert
-      .dom('[data-test-input-damage="0"]')
+      .dom('#nav-attacks [data-test-input-damage="0"]')
       .exists('after add damage type, one damage type should exist');
     assert
-      .dom('[data-test-input-damage="1"]')
+      .dom('#nav-attacks [data-test-input-damage="1"]')
       .exists('after add damage type, a second damage type should exist');
     assert
-      .dom('[data-test-input-damage="2"]')
+      .dom('#nav-attacks [data-test-input-damage="2"]')
       .doesNotExist('after add damage type, a third damage type should exist');
 
     // Customize the damage type dropdown for the newly added damage type
-    await select('[data-test-damage-dropdown="1"]', DamageType.FIRE.name);
+    await select(
+      '#nav-attacks [data-test-damage-dropdown="1"]',
+      DamageType.FIRE.name,
+    );
     assert
-      .dom('[data-test-damage-dropdown="0"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="0"]')
       .hasValue(
         DamageType.PIERCING.name,
         'damage 0 should be piercing (by default)',
       );
     assert
-      .dom('[data-test-damage-dropdown="1"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="1"]')
       .hasValue(
         DamageType.FIRE.name,
         'damage 1 should be fire (after the dropdown reset the value)',
       );
 
     // Add a third damage type
-    await click('[data-test-button-add-damage-type]');
+    await click('#nav-attacks [data-test-button-add-damage-type]');
 
     assert
-      .dom('[data-test-input-damage="0"]')
+      .dom('#nav-attacks [data-test-input-damage="0"]')
       .exists('after a second add damage type, one damage type should exist');
     assert
-      .dom('[data-test-input-damage="1"]')
+      .dom('#nav-attacks [data-test-input-damage="1"]')
       .exists(
         'after a second add damage type, a second damage type should exist',
       );
     assert
-      .dom('[data-test-input-damage="2"]')
+      .dom('#nav-attacks [data-test-input-damage="2"]')
       .exists(
         'after a second add damage type, a third damage type should exist',
       );
     assert
-      .dom('[data-test-input-damage="3"]')
+      .dom('#nav-attacks [data-test-input-damage="3"]')
       .doesNotExist(
         'after a second add damage type, a fourth damage type should exist',
       );
 
     // Customize the damage type dropdown for the newly added damage type
     await select(
-      '[data-test-damage-dropdown="2"]',
+      '#nav-attacks [data-test-damage-dropdown="2"]',
       DamageType.BLUDGEONING.name,
     );
     assert
-      .dom('[data-test-damage-dropdown="0"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="0"]')
       .hasValue(
         DamageType.PIERCING.name,
         'damage 0 should be piercing (by default)',
       );
     assert
-      .dom('[data-test-damage-dropdown="1"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="1"]')
       .hasValue(
         DamageType.FIRE.name,
         'damage 1 should be fire (after the dropdown reset the value)',
       );
     assert
-      .dom('[data-test-damage-dropdown="2"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="2"]')
       .hasValue(
         DamageType.BLUDGEONING.name,
         'damage 2 should be bludgeoning (after the dropdown reset the value)',
       );
 
     // Remove the radiant damage
-    await click('[data-test-button-remove-damage-type="1"]');
+    await click('#nav-attacks [data-test-button-remove-damage-type="1"]');
 
     assert
-      .dom('[data-test-input-damage="0"]')
+      .dom('#nav-attacks [data-test-input-damage="0"]')
       .exists('after add x2 and remove x1, one damage type should exist');
     assert
-      .dom('[data-test-damage-dropdown="0"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="0"]')
       .hasValue(
         DamageType.PIERCING.name,
         'piercing damage should not have been removed',
       );
     assert
-      .dom('[data-test-input-damage="1"]')
+      .dom('#nav-attacks [data-test-input-damage="1"]')
       .exists('after add x2 and remove x1, a second damage type should exist');
     assert
-      .dom('[data-test-damage-dropdown="1"]')
+      .dom('#nav-attacks [data-test-damage-dropdown="1"]')
       .hasValue(
         DamageType.BLUDGEONING.name,
         'bludgeoning damage should not have been removed',
       );
     assert
-      .dom('[data-test-input-damage="2"]')
+      .dom('#nav-attacks [data-test-input-damage="2"]')
       .doesNotExist(
         'after add x2 and remove x1, a third damage type should not exist',
       );
@@ -279,68 +266,68 @@ module('Acceptance | repeated attack form', function (hooks) {
     await visit('/');
 
     // Attack (using the default setup)
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     // There should be one set of attack details displayed
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .exists('details should be displayed for one attack');
     assert
-      .dom('[data-test-data-list="1"]')
+      .dom('#nav-attacks [data-test-data-list="1"]')
       .doesNotExist('only one attack set should be displayed');
 
     // Attack twice more
-    await click('[data-test-button-getDamage]');
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     // There should be three sets of attack details displayed
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .exists('details should be displayed for one attack');
     assert
-      .dom('[data-test-data-list="1"]')
+      .dom('#nav-attacks [data-test-data-list="1"]')
       .exists('details should be displayed for two attacks');
     assert
-      .dom('[data-test-data-list="2"]')
+      .dom('#nav-attacks [data-test-data-list="2"]')
       .exists('details should be displayed for three attacks');
     assert
-      .dom('[data-test-data-list="3"]')
+      .dom('#nav-attacks [data-test-data-list="3"]')
       .doesNotExist('details should not be displayed for a fourth attack');
 
     // Clear the attack log
-    await click('[data-test-button-clear-log]');
+    await click('#nav-attacks [data-test-button-clear-log]');
 
     // No attack details should be displayed
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .doesNotExist('details should no longer be displayed');
 
     // Clicking again should not cause any errors
-    await click('[data-test-button-clear-log]');
+    await click('#nav-attacks [data-test-button-clear-log]');
   });
 
   test('invalidating malformatted fields', async function (this: ElementContext, assert) {
     await visit('/');
     // numberOfAttacks
-    await fillIn('[data-test-input-numberOfAttacks]', '8');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '8');
     assert
-      .dom('[data-test-input-numberOfAttacks]')
+      .dom('#nav-attacks [data-test-input-numberOfAttacks]')
       .isValid('initial number of attacks should be valid');
 
-    await fillIn('[data-test-input-numberOfAttacks]', '-2');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '-2');
     assert
-      .dom('[data-test-input-numberOfAttacks]')
+      .dom('#nav-attacks [data-test-input-numberOfAttacks]')
       .isNotValid('invalid input number of attacks should be flagged');
 
     // toHit
-    await fillIn('[data-test-input-toHit]', '3 - 1d6');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3 - 1d6');
     assert
-      .dom('[data-test-input-toHit]')
+      .dom('#nav-attacks [data-test-input-toHit]')
       .isValid('initial toHit should be valid');
 
-    await fillIn('[data-test-input-toHit]', 'invalid');
+    await fillIn('#nav-attacks [data-test-input-toHit]', 'invalid');
     assert
-      .dom('[data-test-input-toHit]')
+      .dom('#nav-attacks [data-test-input-toHit]')
       .isNotValid('invalid input toHit should be flagged');
   });
 });

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -52,7 +52,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       );
 
     assert
-      .dom('[data-test-attack-detail-list="0"]')
+      .dom('[data-test-detail-list="0"]')
       .isNotVisible(
         'attack detail list should not be displayed before the attack has been requested',
       );
@@ -61,7 +61,7 @@ module('Acceptance | repeated attack form', function (hooks) {
     await click('[data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 8\n' +
           'Target AC: 15\n' +
@@ -78,11 +78,11 @@ module('Acceptance | repeated attack form', function (hooks) {
       .hasTextContaining('Total Damage');
 
     assert
-      .dom('[data-test-attack-detail-list="0"]')
+      .dom('[data-test-detail-list="0"]')
       .isVisible('attack details should be displayed');
 
     assert.equal(
-      this.element.querySelector('[data-test-attack-detail-list="0"]')?.children
+      this.element.querySelector('[data-test-detail-list="0"]')?.children
         .length,
       8,
       '8 attacks should have been displayed',
@@ -115,7 +115,7 @@ module('Acceptance | repeated attack form', function (hooks) {
 
     // The second attack should be displayed first
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 4\n' +
           'Target AC: 15\n' +
@@ -124,11 +124,11 @@ module('Acceptance | repeated attack form', function (hooks) {
       );
 
     assert
-      .dom('[data-test-attack-detail-list="0"]')
+      .dom('[data-test-detail-list="0"]')
       .isVisible('attack details should be displayed for the second attack');
 
     assert.equal(
-      this.element.querySelector('[data-test-attack-detail-list="0"]')?.children
+      this.element.querySelector('[data-test-detail-list="0"]')?.children
         .length,
       4,
       '4 attacks should have been displayed for the second set of attacks',
@@ -136,7 +136,7 @@ module('Acceptance | repeated attack form', function (hooks) {
 
     // The first repeated attack should still be visible
     assert
-      .dom('[data-test-attack-data-list="1"]')
+      .dom('[data-test-data-list="1"]')
       .hasText(
         'Number of attacks: 8\n' +
           'Target AC: 15\n' +
@@ -145,11 +145,11 @@ module('Acceptance | repeated attack form', function (hooks) {
       );
 
     assert
-      .dom('[data-test-attack-detail-list="1"]')
+      .dom('[data-test-detail-list="1"]')
       .isVisible('attack details should be displayed for the first attack');
 
     assert.equal(
-      this.element.querySelector('[data-test-attack-detail-list="1"]')?.children
+      this.element.querySelector('[data-test-detail-list="1"]')?.children
         .length,
       8,
       '8 attacks should have been displayed for the first set of attacks',
@@ -283,10 +283,10 @@ module('Acceptance | repeated attack form', function (hooks) {
 
     // There should be one set of attack details displayed
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .exists('details should be displayed for one attack');
     assert
-      .dom('[data-test-attack-data-list="1"]')
+      .dom('[data-test-data-list="1"]')
       .doesNotExist('only one attack set should be displayed');
 
     // Attack twice more
@@ -295,28 +295,28 @@ module('Acceptance | repeated attack form', function (hooks) {
 
     // There should be three sets of attack details displayed
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .exists('details should be displayed for one attack');
     assert
-      .dom('[data-test-attack-data-list="1"]')
+      .dom('[data-test-data-list="1"]')
       .exists('details should be displayed for two attacks');
     assert
-      .dom('[data-test-attack-data-list="2"]')
-      .exists('details should be displayed for two attacks');
+      .dom('[data-test-data-list="2"]')
+      .exists('details should be displayed for three attacks');
     assert
-      .dom('[data-test-attack-data-list="3"]')
+      .dom('[data-test-data-list="3"]')
       .doesNotExist('details should not be displayed for a fourth attack');
 
     // Clear the attack log
-    await click('[data-test-button-clear-attack-log]');
+    await click('[data-test-button-clear-log]');
 
     // No attack details should be displayed
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .doesNotExist('details should no longer be displayed');
 
     // Clicking again should not cause any errors
-    await click('[data-test-button-clear-attack-log]');
+    await click('[data-test-button-clear-log]');
   });
 
   test('invalidating malformatted fields', async function (this: ElementContext, assert) {

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -11,7 +11,7 @@ import { type ElementContext } from '../types/element-context';
 module('Acceptance | repeated attack form', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('performing single attack set with maximized dice', async function (this: ElementContext, assert) {
+  test('it displays an attack set with maximized dice', async function (this: ElementContext, assert) {
     // Mock randomness so that all dice roll their maximum value
     const fakeRandom = sinon.fake.returns(0.99999999999999);
     const random = this.owner.lookup('service:randomness') as RandomnessService;
@@ -33,7 +33,7 @@ module('Acceptance | repeated attack form', function (hooks) {
     await click('[data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 2\n' +
           'Target AC: 15\n' +
@@ -53,17 +53,17 @@ module('Acceptance | repeated attack form', function (hooks) {
     for (let i = 0; i < 2; i++) {
       // Examine the attack roll section
       assert
-        .dom(`[data-test-attack-roll-detail="0-${i}"]`)
+        .dom(`[data-test-roll-detail="0-${i}"]`)
         .hasAttribute('title', '1d20: 20 | -1d6: 6')
         .hasText('17 to hit (CRIT!)');
 
       // Test the collapsible attack-roll details
       assert
-        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
         .hasAria('expanded', 'false')
         .hasText('17');
       assert
-        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
         .hasText('1d20: 20 -1d6: 6')
         .doesNotHaveClass(
           'show',
@@ -71,18 +71,18 @@ module('Acceptance | repeated attack form', function (hooks) {
         );
 
       // The attack roll details should be visible after a click
-      await click(`[data-test-attack-roll-collapse-link="0-${i}"]`);
+      await click(`[data-test-roll-collapse-link="0-${i}"]`);
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, attack roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
         .hasClass(
           'show',
           'after click, attack roll detail pane should be visible',
@@ -105,7 +105,11 @@ module('Acceptance | repeated attack form', function (hooks) {
         .hasText('14');
       assert
         .dom(`[data-test-damage-roll-collapse-pane="0-${i}-0"]`)
-        .hasText('2d12: 12, 12');
+        .hasText('2d12: 12, 12')
+        .doesNotHaveClass(
+          'show',
+          'damage roll detail pane should start collapsed',
+        );
 
       // The damage roll details should be visible after a click
       await click(`[data-test-damage-roll-collapse-link="0-${i}-0"]`);
@@ -113,10 +117,17 @@ module('Acceptance | repeated attack form', function (hooks) {
       await delay();
       assert
         .dom(`[data-test-damage-roll-collapse-link="0-${i}-0"]`)
-        .hasAria('expanded', 'true');
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, damage roll detail pane should be expanded',
+        );
       assert
         .dom(`[data-test-damage-roll-collapse-pane="0-${i}-0"]`)
-        .hasClass('show');
+        .hasClass(
+          'show',
+          'after click, damage roll detail pane should be visible',
+        );
 
       // Do not test closing the pane; some sort of state appears to persist in
       // Bootstrap between tests, and makes closing the pane fail after the
@@ -124,7 +135,7 @@ module('Acceptance | repeated attack form', function (hooks) {
     }
   });
 
-  test('performing single attack set with minimized dice', async function (this: ElementContext, assert) {
+  test('it displays a single attack set with minimized dice', async function (this: ElementContext, assert) {
     // Mock randomness so that all dice roll their minimum value
     const fakeRandom = sinon.fake.returns(0);
     const random = this.owner.lookup('service:randomness') as RandomnessService;
@@ -138,15 +149,12 @@ module('Acceptance | repeated attack form', function (hooks) {
     await fillIn('[data-test-input-toHit]', '3 - 1D6');
     await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
     await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
-    await click('[data-test-value="advantage"]');
-    await click('[data-test-value="straight"]');
-    await click('[data-test-input-resistant="0"]');
 
     // Calculate the attack
     await click('[data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-attack-data-list="0"]')
+      .dom('[data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 2\n' +
           'Target AC: 15\n' +
@@ -165,17 +173,17 @@ module('Acceptance | repeated attack form', function (hooks) {
     for (let i = 0; i < 2; i++) {
       // Examine the attack roll section
       assert
-        .dom(`[data-test-attack-roll-detail="0-${i}"]`)
+        .dom(`[data-test-roll-detail="0-${i}"]`)
         .hasAttribute('title', '1d20: 1 | -1d6: 1')
         .hasText('3 to hit (NAT 1!)');
 
       // Test the collapsible attack-roll details
       assert
-        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
         .hasAria('expanded', 'false')
         .hasText('3');
       assert
-        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
         .hasText('1d20: 1 -1d6: 1')
         .doesNotHaveClass(
           'show',
@@ -183,18 +191,18 @@ module('Acceptance | repeated attack form', function (hooks) {
         );
 
       // The attack roll details should be visible after a click
-      await click(`[data-test-attack-roll-collapse-link="0-${i}"]`);
+      await click(`[data-test-roll-collapse-link="0-${i}"]`);
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-attack-roll-collapse-link="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, attack roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-attack-roll-collapse-pane="0-${i}"]`)
+        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
         .hasClass(
           'show',
           'after click, attack roll detail pane should be visible',
@@ -206,6 +214,297 @@ module('Acceptance | repeated attack form', function (hooks) {
 
       // The damage section should be empty
       assert.dom(`[data-test-damage-roll-detail="0-${i}-0"]`).doesNotExist();
+    }
+  });
+
+  test('it displays a set with a single attack with constant damage', async function (this: ElementContext, assert) {
+    // Mock randomness so that this attack will hit, but not be a critical hit
+    const fakeRandom = sinon.fake.returns(0.8);
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+
+    // Configure an attack with one repetition and a low AC
+    await fillIn('[data-test-input-numberOfAttacks]', '1');
+    await fillIn('[data-test-input-targetAC]', '5');
+    await fillIn('[data-test-input-toHit]', '3');
+    await fillIn('[data-test-input-damage="0"]', '10');
+    await select('[data-test-damage-dropdown="0"]', DamageType.FIRE.name);
+    await click('[data-test-value="advantage"]');
+
+    // Calculate the attack
+    await click('[data-test-button-getDamage]');
+
+    assert
+      .dom('[data-test-data-list="0"]')
+      .hasText(
+        'Number of attacks: 1\nTarget AC: 5\nAttack roll: 1d20 + 3 (advantage)\n',
+        'the details for the input damage should be displayed',
+      );
+
+    // The attack dealt constant damage; the single hit should be displayed
+    // correctly
+    assert
+      .dom('[data-test-total-damage-header="0"]')
+      .hasText('Total Damage: 10 (1 hit)');
+
+    // The attack roll should not be marked as a crit or as a natural one
+    assert
+      .dom(`[data-test-roll-detail="0-0"]`)
+      .hasAttribute('title', '1d20: 17')
+      .hasText('20 to hit');
+
+    // Examine the damage section
+    assert
+      .dom(`[data-test-damage-roll-detail="0-0-0"]`)
+      .hasAttribute('title', '')
+      .hasText('10 fire damage (10)');
+
+    // The collapsible damage pane should not be present
+    assert
+      .dom('[data-test-damage-roll-collapse-link="0-0-0"]')
+      .doesNotExist(
+        'damage should not be formatted as a link with a collapsble pane if there were no damage dice',
+      );
+  });
+
+  test('it displays multiple sets of repeated attacks', async function (this: ElementContext, assert) {
+    // Mock randomness so that the first attack is a hit and the second misses
+    const fakeRandom = sinon.fake.returns(0.7);
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+
+    // Fill in some details for the first attack
+    await fillIn('[data-test-input-numberOfAttacks]', '2');
+    await fillIn('[data-test-input-targetAC]', '15');
+    await fillIn('[data-test-input-toHit]', '2');
+    await click('[data-test-value="disadvantage"]');
+    // Set up one damage type
+    await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
+    await select(
+      '[data-test-damage-dropdown="0"]',
+      DamageType.BLUDGEONING.name,
+    );
+    await click('[data-test-input-resistant="0"]');
+    await click('[data-test-input-vulnerable="0"]');
+    // Add a second damage type
+    await click('[data-test-button-add-damage-type]');
+    await fillIn('[data-test-input-damage="1"]', '3d6');
+    await select('[data-test-damage-dropdown="1"]', DamageType.COLD.name);
+
+    // Trigger the attack
+    await click('[data-test-button-getDamage]');
+
+    // Change the attack details so that the next set of attacks will miss
+    await fillIn('[data-test-input-numberOfAttacks]', '1');
+    await fillIn('[data-test-input-targetAC]', '22');
+    await click('[data-test-value="straight"]');
+
+    // Trigger the attack
+    await click('[data-test-button-getDamage]');
+
+    // Inspect the second attack's details, which will be displayed first
+    assert
+      .dom('[data-test-data-list="0"]')
+      .hasText(
+        'Number of attacks: 1\n' +
+          'Target AC: 22\n' +
+          'Attack roll: 1d20 + 2\n',
+        'the details for the second set of attacks should be displayed',
+      );
+
+    // With an AC of 22, the attack should have missed
+    assert
+      .dom('[data-test-total-damage-header="0"]')
+      .hasText('Total Damage: 0 (0 hits)');
+
+    // Examine the attack roll section
+    assert
+      .dom(`[data-test-roll-detail="0-0"]`)
+      .hasAttribute('title', '1d20: 15')
+      .hasText('17 to hit');
+
+    // Test the collapsible attack-roll details, making sure that these
+    // function even with multiple attacks
+    assert
+      .dom(`[data-test-roll-collapse-link="0-0"]`)
+      .hasAria('expanded', 'false')
+      .hasText('17');
+    assert
+      .dom(`[data-test-roll-collapse-pane="0-0"]`)
+      .hasText('1d20: 15')
+      .doesNotHaveClass(
+        'show',
+        'attack roll detail pane should start collapsed',
+      );
+
+    // The attack roll details should be visible after a click
+    await click(`[data-test-roll-collapse-link="0-0"]`);
+    // Delay briefly so that the pane finishes opening
+    await delay();
+    assert
+      .dom(`[data-test-roll-collapse-link="0-0"]`)
+      .hasAria(
+        'expanded',
+        'true',
+        'after click, attack roll detail pane should be expanded',
+      );
+    assert
+      .dom(`[data-test-roll-collapse-pane="0-0"]`)
+      .hasClass(
+        'show',
+        'after click, attack roll detail pane should be visible',
+      );
+
+    // Do not test closing the pane; some sort of state appears to persist in
+    // Bootstrap between tests, and makes closing the pane fail after the
+    // first test that renders this form.
+
+    // No damage was inflicted, since this did not hit
+    assert.dom(`[data-test-damage-roll-detail="0-0-0"]`).doesNotExist();
+
+    // Inspect the first attack's details
+    assert
+      .dom('[data-test-data-list="1"]')
+      .hasText(
+        'Number of attacks: 2\n' +
+          'Target AC: 15\n' +
+          'Attack roll: 1d20 + 2 (disadvantage)\n',
+        'the details for the first set of attacks should be displayed',
+      );
+
+    // Each d6 rolled a 5; the d12 rolled a 9, for [(9 + 5) / 2 * 2] + 3 * 5 =
+    // 29 damage for each attack
+    assert
+      .dom('[data-test-total-damage-header="1"]')
+      .hasText('Total Damage: 58 (2 hits)');
+
+    for (let i = 0; i < 2; i++) {
+      // Examine the attack roll section
+      assert
+        .dom(`[data-test-roll-detail="1-${i}"]`)
+        .hasAttribute('title', '1d20: 15')
+        .hasText('17 to hit');
+
+      // Test the collapsible attack-roll details
+      assert
+        .dom(`[data-test-roll-collapse-link="1-${i}"]`)
+        .hasAria('expanded', 'false')
+        .hasText('17');
+      assert
+        .dom(`[data-test-roll-collapse-pane="1-${i}"]`)
+        .hasText('1d20: 15')
+        .doesNotHaveClass(
+          'show',
+          'attack roll detail pane should start collapsed',
+        );
+
+      // The attack roll details should be visible after a click
+      await click(`[data-test-roll-collapse-link="1-${i}"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`[data-test-roll-collapse-link="1-${i}"]`)
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, attack roll detail pane should be expanded',
+        );
+      assert
+        .dom(`[data-test-roll-collapse-pane="1-${i}"]`)
+        .hasClass(
+          'show',
+          'after click, attack roll detail pane should be visible',
+        );
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
+
+      // Examine the first damage section
+      assert
+        .dom(`[data-test-damage-roll-detail="1-${i}-0"]`)
+        .hasAttribute('title', '1d12: 9')
+        .hasText('14 bludgeoning damage (1d12 + 5) (resisted) (vulnerable)');
+
+      // Test the collapsible damage pane
+      assert
+        .dom(`[data-test-damage-roll-collapse-link="1-${i}-0"]`)
+        .hasAria('expanded', 'false')
+        .hasText('14');
+      assert
+        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-0"]`)
+        .hasText('1d12: 9')
+        .doesNotHaveClass(
+          'show',
+          'damage roll detail pane should start collapsed',
+        );
+
+      // The damage roll details should be visible after a click
+      await click(`[data-test-damage-roll-collapse-link="1-${i}-0"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`[data-test-damage-roll-collapse-link="1-${i}-0"]`)
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, damage roll detail pane should be expanded',
+        );
+      assert
+        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-0"]`)
+        .hasClass(
+          'show',
+          'after click, damage roll detail pane should be visible',
+        );
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
+
+      // Examine the second damage section
+      assert
+        .dom(`[data-test-damage-roll-detail="1-${i}-1"]`)
+        .hasAttribute('title', '3d6: 5, 5, 5')
+        .hasText('15 cold damage (3d6)');
+
+      // Test the collapsible damage pane
+      assert
+        .dom(`[data-test-damage-roll-collapse-link="1-${i}-1"]`)
+        .hasAria('expanded', 'false')
+        .hasText('15');
+      assert
+        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-1"]`)
+        .hasText('3d6: 5, 5, 5')
+        .doesNotHaveClass(
+          'show',
+          'damage roll detail pane should start collapsed',
+        );
+
+      // The damage roll details should be visible after a click
+      await click(`[data-test-damage-roll-collapse-link="1-${i}-1"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`[data-test-damage-roll-collapse-link="1-${i}-1"]`)
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, damage roll detail pane should be expanded',
+        );
+      assert
+        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-1"]`)
+        .hasClass(
+          'show',
+          'after click, damage roll detail pane should be visible',
+        );
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
     }
   });
 

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -20,20 +20,23 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await visit('/');
 
     // Fill in some details for the attack
-    await fillIn('[data-test-input-numberOfAttacks]', '2');
-    await fillIn('[data-test-input-targetAC]', '15');
-    await fillIn('[data-test-input-toHit]', '3 - 1D6');
-    await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
-    await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
-    await click('[data-test-value="advantage"]');
-    await click('[data-test-value="straight"]');
-    await click('[data-test-input-resistant="0"]');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '2');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '15');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3 - 1D6');
+    await fillIn('#nav-attacks [data-test-input-damage="0"]', '1d12 + 5');
+    await select(
+      '#nav-attacks [data-test-damage-dropdown="0"]',
+      DamageType.RADIANT.name,
+    );
+    await click('#nav-attacks [data-test-value="advantage"]');
+    await click('#nav-attacks [data-test-value="straight"]');
+    await click('#nav-attacks [data-test-input-resistant="0"]');
 
     // Calculate the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 2\n' +
           'Target AC: 15\n' +
@@ -44,26 +47,25 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     // Both attacks were a critical hit, so each dealt 12 + 12 + 5 = 29 damage,
     // halved to 14 by resistance
     assert
-      .dom('[data-test-total-damage-header="0"]')
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
       .hasText('Total Damage: 28 (2 hits)');
 
-    // Check that the displayed text matches the expected die rolls (other
-    // tests check additional details of the display). Since all dice are
-    // maximized, the two attacks are identical.
+    // Check that the displayed text matches the expected die rolls. Since all
+    // dice are maximized, the two attacks are identical.
     for (let i = 0; i < 2; i++) {
       // Examine the attack roll section
       assert
-        .dom(`[data-test-roll-detail="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-detail="0-${i}"]`)
         .hasAttribute('title', '1d20: 20 | -1d6: 6')
         .hasText('17 to hit (CRIT!)');
 
       // Test the collapsible attack-roll details
       assert
-        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`)
         .hasAria('expanded', 'false')
         .hasText('17');
       assert
-        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-pane="0-${i}"]`)
         .hasText('1d20: 20 -1d6: 6')
         .doesNotHaveClass(
           'show',
@@ -71,18 +73,18 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         );
 
       // The attack roll details should be visible after a click
-      await click(`[data-test-roll-collapse-link="0-${i}"]`);
+      await click(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`);
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, attack roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-pane="0-${i}"]`)
         .hasClass(
           'show',
           'after click, attack roll detail pane should be visible',
@@ -94,17 +96,17 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
 
       // Examine the damage section
       assert
-        .dom(`[data-test-damage-roll-detail="0-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-detail="0-${i}-0"]`)
         .hasAttribute('title', '2d12: 12, 12')
         .hasText('14 radiant damage (2d12 + 5) (resisted)');
 
       // Test the collapsible damage pane
       assert
-        .dom(`[data-test-damage-roll-collapse-link="0-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-link="0-${i}-0"]`)
         .hasAria('expanded', 'false')
         .hasText('14');
       assert
-        .dom(`[data-test-damage-roll-collapse-pane="0-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-pane="0-${i}-0"]`)
         .hasText('2d12: 12, 12')
         .doesNotHaveClass(
           'show',
@@ -112,18 +114,20 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         );
 
       // The damage roll details should be visible after a click
-      await click(`[data-test-damage-roll-collapse-link="0-${i}-0"]`);
+      await click(
+        `#nav-attacks [data-test-damage-roll-collapse-link="0-${i}-0"]`,
+      );
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-damage-roll-collapse-link="0-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-link="0-${i}-0"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, damage roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-damage-roll-collapse-pane="0-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-pane="0-${i}-0"]`)
         .hasClass(
           'show',
           'after click, damage roll detail pane should be visible',
@@ -144,17 +148,20 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await visit('/');
 
     // Fill in some details for the attack
-    await fillIn('[data-test-input-numberOfAttacks]', '2');
-    await fillIn('[data-test-input-targetAC]', '15');
-    await fillIn('[data-test-input-toHit]', '3 - 1D6');
-    await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
-    await select('[data-test-damage-dropdown="0"]', DamageType.RADIANT.name);
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '2');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '15');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3 - 1D6');
+    await fillIn('#nav-attacks [data-test-input-damage="0"]', '1d12 + 5');
+    await select(
+      '#nav-attacks [data-test-damage-dropdown="0"]',
+      DamageType.RADIANT.name,
+    );
 
     // Calculate the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 2\n' +
           'Target AC: 15\n' +
@@ -164,26 +171,25 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
 
     // Both attacks were a natural one
     assert
-      .dom('[data-test-total-damage-header="0"]')
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
       .hasText('Total Damage: 0 (0 hits)');
 
-    // Check that the displayed text matches the expected die rolls (other
-    // tests check additional details of the display). Since all dice are
-    // minimized, the two attacks are identical.
+    // Check that the displayed text matches the expected die rolls. Since all
+    // dice are minimized, the two attacks are identical.
     for (let i = 0; i < 2; i++) {
       // Examine the attack roll section
       assert
-        .dom(`[data-test-roll-detail="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-detail="0-${i}"]`)
         .hasAttribute('title', '1d20: 1 | -1d6: 1')
         .hasText('3 to hit (NAT 1!)');
 
       // Test the collapsible attack-roll details
       assert
-        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`)
         .hasAria('expanded', 'false')
         .hasText('3');
       assert
-        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-pane="0-${i}"]`)
         .hasText('1d20: 1 -1d6: 1')
         .doesNotHaveClass(
           'show',
@@ -191,18 +197,18 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         );
 
       // The attack roll details should be visible after a click
-      await click(`[data-test-roll-collapse-link="0-${i}"]`);
+      await click(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`);
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-roll-collapse-link="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, attack roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-roll-collapse-pane="0-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-pane="0-${i}"]`)
         .hasClass(
           'show',
           'after click, attack roll detail pane should be visible',
@@ -213,7 +219,9 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
       // first test that renders this form.
 
       // The damage section should be empty
-      assert.dom(`[data-test-damage-roll-detail="0-${i}-0"]`).doesNotExist();
+      assert
+        .dom(`#nav-attacks [data-test-damage-roll-detail="0-${i}-0"]`)
+        .doesNotExist();
     }
   });
 
@@ -226,18 +234,21 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await visit('/');
 
     // Configure an attack with one repetition and a low AC
-    await fillIn('[data-test-input-numberOfAttacks]', '1');
-    await fillIn('[data-test-input-targetAC]', '5');
-    await fillIn('[data-test-input-toHit]', '3');
-    await fillIn('[data-test-input-damage="0"]', '10');
-    await select('[data-test-damage-dropdown="0"]', DamageType.FIRE.name);
-    await click('[data-test-value="advantage"]');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '1');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '5');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '3');
+    await fillIn('#nav-attacks [data-test-input-damage="0"]', '10');
+    await select(
+      '#nav-attacks [data-test-damage-dropdown="0"]',
+      DamageType.FIRE.name,
+    );
+    await click('#nav-attacks [data-test-value="advantage"]');
 
     // Calculate the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 1\nTarget AC: 5\nAttack roll: 1d20 + 3 (advantage)\n',
         'the details for the input damage should be displayed',
@@ -246,24 +257,24 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     // The attack dealt constant damage; the single hit should be displayed
     // correctly
     assert
-      .dom('[data-test-total-damage-header="0"]')
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
       .hasText('Total Damage: 10 (1 hit)');
 
     // The attack roll should not be marked as a crit or as a natural one
     assert
-      .dom(`[data-test-roll-detail="0-0"]`)
+      .dom(`#nav-attacks [data-test-roll-detail="0-0"]`)
       .hasAttribute('title', '1d20: 17')
       .hasText('20 to hit');
 
     // Examine the damage section
     assert
-      .dom(`[data-test-damage-roll-detail="0-0-0"]`)
+      .dom(`#nav-attacks [data-test-damage-roll-detail="0-0-0"]`)
       .hasAttribute('title', '')
       .hasText('10 fire damage (10)');
 
     // The collapsible damage pane should not be present
     assert
-      .dom('[data-test-damage-roll-collapse-link="0-0-0"]')
+      .dom('#nav-attacks [data-test-damage-roll-collapse-link="0-0-0"]')
       .doesNotExist(
         'damage should not be formatted as a link with a collapsble pane if there were no damage dice',
       );
@@ -278,37 +289,40 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await visit('/');
 
     // Fill in some details for the first attack
-    await fillIn('[data-test-input-numberOfAttacks]', '2');
-    await fillIn('[data-test-input-targetAC]', '15');
-    await fillIn('[data-test-input-toHit]', '2');
-    await click('[data-test-value="disadvantage"]');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '2');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '15');
+    await fillIn('#nav-attacks [data-test-input-toHit]', '2');
+    await click('#nav-attacks [data-test-value="disadvantage"]');
     // Set up one damage type
-    await fillIn('[data-test-input-damage="0"]', '1d12 + 5');
+    await fillIn('#nav-attacks [data-test-input-damage="0"]', '1d12 + 5');
     await select(
-      '[data-test-damage-dropdown="0"]',
+      '#nav-attacks [data-test-damage-dropdown="0"]',
       DamageType.BLUDGEONING.name,
     );
-    await click('[data-test-input-resistant="0"]');
-    await click('[data-test-input-vulnerable="0"]');
+    await click('#nav-attacks [data-test-input-resistant="0"]');
+    await click('#nav-attacks [data-test-input-vulnerable="0"]');
     // Add a second damage type
-    await click('[data-test-button-add-damage-type]');
-    await fillIn('[data-test-input-damage="1"]', '3d6');
-    await select('[data-test-damage-dropdown="1"]', DamageType.COLD.name);
+    await click('#nav-attacks [data-test-button-add-damage-type]');
+    await fillIn('#nav-attacks [data-test-input-damage="1"]', '3d6');
+    await select(
+      '#nav-attacks [data-test-damage-dropdown="1"]',
+      DamageType.COLD.name,
+    );
 
     // Trigger the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     // Change the attack details so that the next set of attacks will miss
-    await fillIn('[data-test-input-numberOfAttacks]', '1');
-    await fillIn('[data-test-input-targetAC]', '22');
-    await click('[data-test-value="straight"]');
+    await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '1');
+    await fillIn('#nav-attacks [data-test-input-targetAC]', '22');
+    await click('#nav-attacks [data-test-value="straight"]');
 
     // Trigger the attack
-    await click('[data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-getDamage]');
 
     // Inspect the second attack's details, which will be displayed first
     assert
-      .dom('[data-test-data-list="0"]')
+      .dom('#nav-attacks [data-test-data-list="0"]')
       .hasText(
         'Number of attacks: 1\n' +
           'Target AC: 22\n' +
@@ -318,23 +332,23 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
 
     // With an AC of 22, the attack should have missed
     assert
-      .dom('[data-test-total-damage-header="0"]')
+      .dom('#nav-attacks [data-test-total-damage-header="0"]')
       .hasText('Total Damage: 0 (0 hits)');
 
     // Examine the attack roll section
     assert
-      .dom(`[data-test-roll-detail="0-0"]`)
+      .dom(`#nav-attacks [data-test-roll-detail="0-0"]`)
       .hasAttribute('title', '1d20: 15')
       .hasText('17 to hit');
 
     // Test the collapsible attack-roll details, making sure that these
     // function even with multiple attacks
     assert
-      .dom(`[data-test-roll-collapse-link="0-0"]`)
+      .dom(`#nav-attacks [data-test-roll-collapse-link="0-0"]`)
       .hasAria('expanded', 'false')
       .hasText('17');
     assert
-      .dom(`[data-test-roll-collapse-pane="0-0"]`)
+      .dom(`#nav-attacks [data-test-roll-collapse-pane="0-0"]`)
       .hasText('1d20: 15')
       .doesNotHaveClass(
         'show',
@@ -342,18 +356,18 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
       );
 
     // The attack roll details should be visible after a click
-    await click(`[data-test-roll-collapse-link="0-0"]`);
+    await click(`#nav-attacks [data-test-roll-collapse-link="0-0"]`);
     // Delay briefly so that the pane finishes opening
     await delay();
     assert
-      .dom(`[data-test-roll-collapse-link="0-0"]`)
+      .dom(`#nav-attacks [data-test-roll-collapse-link="0-0"]`)
       .hasAria(
         'expanded',
         'true',
         'after click, attack roll detail pane should be expanded',
       );
     assert
-      .dom(`[data-test-roll-collapse-pane="0-0"]`)
+      .dom(`#nav-attacks [data-test-roll-collapse-pane="0-0"]`)
       .hasClass(
         'show',
         'after click, attack roll detail pane should be visible',
@@ -364,11 +378,13 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     // first test that renders this form.
 
     // No damage was inflicted, since this did not hit
-    assert.dom(`[data-test-damage-roll-detail="0-0-0"]`).doesNotExist();
+    assert
+      .dom(`#nav-attacks [data-test-damage-roll-detail="0-0-0"]`)
+      .doesNotExist();
 
     // Inspect the first attack's details
     assert
-      .dom('[data-test-data-list="1"]')
+      .dom('#nav-attacks [data-test-data-list="1"]')
       .hasText(
         'Number of attacks: 2\n' +
           'Target AC: 15\n' +
@@ -379,23 +395,23 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     // Each d6 rolled a 5; the d12 rolled a 9, for [(9 + 5) / 2 * 2] + 3 * 5 =
     // 29 damage for each attack
     assert
-      .dom('[data-test-total-damage-header="1"]')
+      .dom('#nav-attacks [data-test-total-damage-header="1"]')
       .hasText('Total Damage: 58 (2 hits)');
 
     for (let i = 0; i < 2; i++) {
       // Examine the attack roll section
       assert
-        .dom(`[data-test-roll-detail="1-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-detail="1-${i}"]`)
         .hasAttribute('title', '1d20: 15')
         .hasText('17 to hit');
 
       // Test the collapsible attack-roll details
       assert
-        .dom(`[data-test-roll-collapse-link="1-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-link="1-${i}"]`)
         .hasAria('expanded', 'false')
         .hasText('17');
       assert
-        .dom(`[data-test-roll-collapse-pane="1-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-pane="1-${i}"]`)
         .hasText('1d20: 15')
         .doesNotHaveClass(
           'show',
@@ -403,18 +419,18 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         );
 
       // The attack roll details should be visible after a click
-      await click(`[data-test-roll-collapse-link="1-${i}"]`);
+      await click(`#nav-attacks [data-test-roll-collapse-link="1-${i}"]`);
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-roll-collapse-link="1-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-link="1-${i}"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, attack roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-roll-collapse-pane="1-${i}"]`)
+        .dom(`#nav-attacks [data-test-roll-collapse-pane="1-${i}"]`)
         .hasClass(
           'show',
           'after click, attack roll detail pane should be visible',
@@ -426,17 +442,17 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
 
       // Examine the first damage section
       assert
-        .dom(`[data-test-damage-roll-detail="1-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-detail="1-${i}-0"]`)
         .hasAttribute('title', '1d12: 9')
         .hasText('14 bludgeoning damage (1d12 + 5) (resisted) (vulnerable)');
 
       // Test the collapsible damage pane
       assert
-        .dom(`[data-test-damage-roll-collapse-link="1-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-link="1-${i}-0"]`)
         .hasAria('expanded', 'false')
         .hasText('14');
       assert
-        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-pane="1-${i}-0"]`)
         .hasText('1d12: 9')
         .doesNotHaveClass(
           'show',
@@ -444,18 +460,20 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         );
 
       // The damage roll details should be visible after a click
-      await click(`[data-test-damage-roll-collapse-link="1-${i}-0"]`);
+      await click(
+        `#nav-attacks [data-test-damage-roll-collapse-link="1-${i}-0"]`,
+      );
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-damage-roll-collapse-link="1-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-link="1-${i}-0"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, damage roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-0"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-pane="1-${i}-0"]`)
         .hasClass(
           'show',
           'after click, damage roll detail pane should be visible',
@@ -467,17 +485,17 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
 
       // Examine the second damage section
       assert
-        .dom(`[data-test-damage-roll-detail="1-${i}-1"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-detail="1-${i}-1"]`)
         .hasAttribute('title', '3d6: 5, 5, 5')
         .hasText('15 cold damage (3d6)');
 
       // Test the collapsible damage pane
       assert
-        .dom(`[data-test-damage-roll-collapse-link="1-${i}-1"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-link="1-${i}-1"]`)
         .hasAria('expanded', 'false')
         .hasText('15');
       assert
-        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-1"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-pane="1-${i}-1"]`)
         .hasText('3d6: 5, 5, 5')
         .doesNotHaveClass(
           'show',
@@ -485,18 +503,20 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         );
 
       // The damage roll details should be visible after a click
-      await click(`[data-test-damage-roll-collapse-link="1-${i}-1"]`);
+      await click(
+        `#nav-attacks [data-test-damage-roll-collapse-link="1-${i}-1"]`,
+      );
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`[data-test-damage-roll-collapse-link="1-${i}-1"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-link="1-${i}-1"]`)
         .hasAria(
           'expanded',
           'true',
           'after click, damage roll detail pane should be expanded',
         );
       assert
-        .dom(`[data-test-damage-roll-collapse-pane="1-${i}-1"]`)
+        .dom(`#nav-attacks [data-test-damage-roll-collapse-pane="1-${i}-1"]`)
         .hasClass(
           'show',
           'after click, damage roll detail pane should be visible',

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -8,7 +8,7 @@ import type RandomnessService from 'multiattack-5e/services/randomness';
 
 import { type ElementContext } from '../types/element-context';
 
-module('Acceptance | repeated attack form', function (hooks) {
+module('Acceptance | repeated attack form with fake dice', function (hooks) {
   setupApplicationTest(hooks);
 
   test('it displays an attack set with maximized dice', async function (this: ElementContext, assert) {

--- a/tests/acceptance/repeated-save-form-test.ts
+++ b/tests/acceptance/repeated-save-form-test.ts
@@ -1,0 +1,313 @@
+import { click, fillIn, select, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import DamageType from 'multiattack-5e/components/damage-type-enum';
+
+import { type ElementContext } from '../types/element-context';
+
+module('Acceptance | repeated save form', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('performing single set of saves', async function (this: ElementContext, assert) {
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+
+    // Fill in some details for the save
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '8');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '15');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '3 - 1D6');
+    await fillIn('#nav-saves [data-test-input-damage="0"]', '4d8');
+    await select(
+      '#nav-saves [data-test-damage-dropdown="0"]',
+      DamageType.RADIANT.name,
+    );
+    await click('#nav-saves [data-test-value="advantage"]');
+    await click('#nav-saves [data-test-value="disadvantage"]');
+    await click('#nav-saves [data-test-input-resistant="0"]');
+
+    assert
+      .dom('#nav-saves [data-test-total-damage-header="0"]')
+      .isNotVisible(
+        'damage header should not be displayed before the save has been requested',
+      );
+
+    // Execute the group of saves
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .hasText(
+        'Number of saves: 8\n' +
+          'Save DC: 15\n' +
+          'Saving throw: 1d20 - 1d6 + 3 (disadvantage)\n',
+        'the details for the set of saves should be displayed',
+      );
+
+    assert
+      .dom('#nav-saves [data-test-total-damage-header="0"]')
+      .isVisible('damage header should be displayed')
+      .hasTextContaining('Total Damage');
+
+    assert
+      .dom('#nav-saves [data-test-detail-list="0"]')
+      .isVisible('individual save details should be displayed');
+
+    assert.equal(
+      this.element.querySelector('#nav-saves [data-test-detail-list="0"]')!
+        .children.length,
+      8,
+      '8 saves should have been displayed',
+    );
+  });
+
+  test('performing repeated sets of saves', async function (this: ElementContext, assert) {
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+
+    // Fill in some details for the saves
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '8');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '10');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '3 - 1d6');
+
+    // Roll the saves
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    // Change some save details
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '4');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '15');
+    await click('#nav-saves [data-test-value="advantage"]');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '3');
+
+    // Roll saves again
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    // The second save should be displayed first
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .hasText(
+        'Number of saves: 4\n' +
+          'Save DC: 15\n' +
+          'Saving throw: 1d20 + 3 (advantage)\n',
+        'the details for the second set of saves should be displayed',
+      );
+
+    assert
+      .dom('#nav-saves [data-test-detail-list="0"]')
+      .isVisible('save details should be displayed for the second save');
+
+    assert.equal(
+      this.element.querySelector('#nav-saves [data-test-detail-list="0"]')!
+        .children.length,
+      4,
+      '4 saves should have been displayed for the second set of saves',
+    );
+
+    // The first repeated save should still be visible
+    assert
+      .dom('#nav-saves [data-test-data-list="1"]')
+      .hasText(
+        'Number of saves: 8\n' +
+          'Save DC: 10\n' +
+          'Saving throw: 1d20 - 1d6 + 3\n',
+        'the details for the first set of saves should be displayed',
+      );
+
+    assert
+      .dom('#nav-saves [data-test-detail-list="1"]')
+      .isVisible('save details should be displayed for the first save');
+
+    assert.equal(
+      this.element.querySelector('#nav-saves [data-test-detail-list="1"]')!
+        .children.length,
+      8,
+      '8 saves should have been displayed for the first set of saves',
+    );
+  });
+
+  test('adding and removing damage types', async function (assert) {
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+
+    // Initially, there should be one damage type displayed
+    assert
+      .dom('#nav-saves [data-test-input-damage="0"]')
+      .exists('one damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-input-damage="1"]')
+      .doesNotExist('only one damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="0"]')
+      .hasValue(DamageType.FIRE.name, 'damage 0 should be fire (by default)');
+
+    // Add another damage type
+    await click('#nav-saves [data-test-button-add-damage-type]');
+
+    assert
+      .dom('#nav-saves [data-test-input-damage="0"]')
+      .exists('after add damage type, one damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-input-damage="1"]')
+      .exists('after add damage type, a second damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-input-damage="2"]')
+      .doesNotExist('after add damage type, a third damage type should exist');
+
+    // Customize the damage type dropdown for the newly added damage type
+    await select(
+      '#nav-saves [data-test-damage-dropdown="1"]',
+      DamageType.COLD.name,
+    );
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="0"]')
+      .hasValue(DamageType.FIRE.name, 'damage 0 should be fire (by default)');
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="1"]')
+      .hasValue(
+        DamageType.COLD.name,
+        'damage 1 should be cold (after the dropdown reset the value)',
+      );
+
+    // Add a third damage type
+    await click('#nav-saves [data-test-button-add-damage-type]');
+
+    assert
+      .dom('#nav-saves [data-test-input-damage="0"]')
+      .exists('after a second add damage type, one damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-input-damage="1"]')
+      .exists(
+        'after a second add damage type, a second damage type should exist',
+      );
+    assert
+      .dom('#nav-saves [data-test-input-damage="2"]')
+      .exists(
+        'after a second add damage type, a third damage type should exist',
+      );
+    assert
+      .dom('#nav-saves [data-test-input-damage="3"]')
+      .doesNotExist(
+        'after a second add damage type, a fourth damage type should exist',
+      );
+
+    // Customize the damage type dropdown for the newly added damage type
+    await select(
+      '#nav-saves [data-test-damage-dropdown="2"]',
+      DamageType.BLUDGEONING.name,
+    );
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="0"]')
+      .hasValue(DamageType.FIRE.name, 'damage 0 should be fire (by default)');
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="1"]')
+      .hasValue(
+        DamageType.COLD.name,
+        'damage 1 should be cold (after the dropdown reset the value)',
+      );
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="2"]')
+      .hasValue(
+        DamageType.BLUDGEONING.name,
+        'damage 2 should be bludgeoning (after the dropdown reset the value)',
+      );
+
+    // Remove the radiant damage
+    await click('#nav-saves [data-test-button-remove-damage-type="1"]');
+
+    assert
+      .dom('#nav-saves [data-test-input-damage="0"]')
+      .exists('after add x2 and remove x1, one damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="0"]')
+      .hasValue(
+        DamageType.FIRE.name,
+        'fire damage should not have been removed',
+      );
+    assert
+      .dom('#nav-saves [data-test-input-damage="1"]')
+      .exists('after add x2 and remove x1, a second damage type should exist');
+    assert
+      .dom('#nav-saves [data-test-damage-dropdown="1"]')
+      .hasValue(
+        DamageType.BLUDGEONING.name,
+        'bludgeoning damage should not have been removed',
+      );
+    assert
+      .dom('#nav-saves [data-test-input-damage="2"]')
+      .doesNotExist(
+        'after add x2 and remove x1, a third damage type should not exist',
+      );
+  });
+
+  test('clearing the save log', async function (this: ElementContext, assert) {
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+
+    // Make a set of saves (using the default setup)
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    // There should be one set of save details displayed
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .exists('details should be displayed for one set of saves');
+    assert
+      .dom('#nav-saves [data-test-data-list="1"]')
+      .doesNotExist('only one save set should be displayed');
+
+    // Roll saves twice more
+    await click('#nav-saves [data-test-button-rollSaves]');
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    // There should be three sets of save details displayed
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .exists('details should be displayed for one save');
+    assert
+      .dom('#nav-saves [data-test-data-list="1"]')
+      .exists('details should be displayed for two saves');
+    assert
+      .dom('#nav-saves [data-test-data-list="2"]')
+      .exists('details should be displayed for three saves');
+    assert
+      .dom('#nav-saves [data-test-data-list="3"]')
+      .doesNotExist('details should not be displayed for a fourth save');
+
+    // Clear the save log
+    await click('#nav-saves [data-test-button-clear-log]');
+
+    // No save details should be displayed
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .doesNotExist('details should no longer be displayed');
+
+    // Clicking again should not cause any errors
+    await click('#nav-saves [data-test-button-clear-log]');
+  });
+
+  test('invalidating malformatted fields', async function (this: ElementContext, assert) {
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+
+    // numberOfSaves
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '8');
+    assert
+      .dom('#nav-saves [data-test-input-numberOfSaves]')
+      .isValid('initial number of saves should be valid');
+
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '-2');
+    assert
+      .dom('#nav-saves [data-test-input-numberOfSaves]')
+      .isNotValid('invalid input number of saves should be flagged');
+
+    // saveMod
+    await fillIn('#nav-saves [data-test-input-saveMod]', '3 - 1d6');
+    assert
+      .dom('#nav-saves [data-test-input-saveMod]')
+      .isValid('initial saveMod should be valid');
+
+    await fillIn('#nav-saves [data-test-input-saveMod]', 'invalid');
+    assert
+      .dom('#nav-saves [data-test-input-saveMod]')
+      .isNotValid('invalid input saveMod should be flagged');
+  });
+});

--- a/tests/acceptance/repeated-save-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-save-form-with-fakes-test.ts
@@ -1,0 +1,183 @@
+import { click, fillIn, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+import type RandomnessService from 'multiattack-5e/services/randomness';
+
+import { type ElementContext } from '../types/element-context';
+
+module('Acceptance | repeated save form with fake dice', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('it displays a passed save with maximized dice', async function (this: ElementContext, assert) {
+    // Mock randomness so that all dice roll their maximum value
+    const fakeRandom = sinon.fake.returns(0.99999999999999);
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+
+    // Fill in some details for the saves
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '1');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '14');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '-1D4');
+
+    // Roll the saves
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .hasText(
+        'Number of saves: 1\nSave DC: 14\nSaving throw: 1d20 - 1d4\n',
+        'the details for the set of saves should be displayed',
+      );
+
+    // Saves do not yet inflict damage
+    assert
+      .dom('#nav-saves [data-test-total-damage-header="0"]')
+      .hasText('Total Damage: 0 (1 pass)');
+
+    // Examine the saving throw details
+    const detailsList = this.element.querySelector(
+      '[data-test-detail-list="0"]',
+    )!.children;
+
+    assert.equal(
+      detailsList[0]?.className,
+      'li-success',
+      'saving throw should have bullet point formatted as a success',
+    );
+
+    // Check the saving throw text
+    assert
+      .dom(`#nav-saves [data-test-roll-detail="0-0"]`)
+      .hasAttribute('title', '1d20: 20 | -1d4: 4')
+      .hasText('16 to save');
+
+    // Test the collapsible saving throw details
+    assert
+      .dom(`#nav-saves [data-test-roll-collapse-link="0-0"]`)
+      .hasAria('expanded', 'false')
+      .hasText('16');
+    assert
+      .dom(`#nav-saves [data-test-roll-collapse-pane="0-0"]`)
+      .hasText('1d20: 20 -1d4: 4')
+      .doesNotHaveClass(
+        'show',
+        'saving throw detail pane should start collapsed',
+      );
+
+    // The saving throw roll details should be visible after a click
+    await click(`#nav-saves [data-test-roll-collapse-link="0-0"]`);
+    // Delay briefly so that the pane finishes opening
+    await delay();
+    assert
+      .dom(`#nav-saves [data-test-roll-collapse-link="0-0"]`)
+      .hasAria(
+        'expanded',
+        'true',
+        'after click, saving throw roll detail pane should be expanded',
+      );
+    assert
+      .dom(`#nav-saves [data-test-roll-collapse-pane="0-0"]`)
+      .hasClass(
+        'show',
+        'after click, saving throw roll detail pane should be visible',
+      );
+
+    // Do not test closing the pane; some sort of state appears to persist in
+    // Bootstrap between tests, and makes closing the pane fail after the
+    // first test that renders this form.
+  });
+
+  test('it displays a set of failed saves with minimized dice', async function (this: ElementContext, assert) {
+    // Mock randomness so that all dice roll their minimum value
+    const fakeRandom = sinon.fake.returns(0);
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+
+    // Fill in some details for the saves
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '3');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '14');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '1d6+3');
+
+    // Roll the saves
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .hasText(
+        'Number of saves: 3\nSave DC: 14\nSaving throw: 1d20 + 1d6 + 3\n',
+        'the details for the set of saves should be displayed',
+      );
+
+    // Saves do not yet inflict damage
+    assert
+      .dom('#nav-saves [data-test-total-damage-header="0"]')
+      .hasText('Total Damage: 0 (0 passes)');
+
+    // Check that the displayed text matches the expected die rolls. Since all
+    // dice are minimized, the three saves are identical.
+    const detailsList = this.element.querySelector(
+      '[data-test-detail-list="0"]',
+    )!.children;
+
+    for (let i = 0; i < 3; i++) {
+      assert.equal(
+        detailsList[0]?.className,
+        'li-fail',
+        'saving throw should have bullet point formatted as a failure',
+      );
+
+      // Examine the saving throw text
+      assert
+        .dom(`#nav-saves [data-test-roll-detail="0-${i}"]`)
+        .hasAttribute('title', '1d20: 1 | 1d6: 1')
+        .hasText('5 to save');
+
+      // Test the collapsible saving throw details
+      assert
+        .dom(`#nav-saves [data-test-roll-collapse-link="0-${i}"]`)
+        .hasAria('expanded', 'false')
+        .hasText('5');
+      assert
+        .dom(`#nav-saves [data-test-roll-collapse-pane="0-${i}"]`)
+        .hasText('1d20: 1 1d6: 1')
+        .doesNotHaveClass(
+          'show',
+          'saving throw detail pane should start collapsed',
+        );
+
+      // The saving throw roll details should be visible after a click
+      await click(`#nav-saves [data-test-roll-collapse-link="0-${i}"]`);
+      // Delay briefly so that the pane finishes opening
+      await delay();
+      assert
+        .dom(`#nav-saves [data-test-roll-collapse-link="0-${i}"]`)
+        .hasAria(
+          'expanded',
+          'true',
+          'after click, saving throw roll detail pane should be expanded',
+        );
+      assert
+        .dom(`#nav-saves [data-test-roll-collapse-pane="0-${i}"]`)
+        .hasClass(
+          'show',
+          'after click, saving throw roll detail pane should be visible',
+        );
+
+      // Do not test closing the pane; some sort of state appears to persist in
+      // Bootstrap between tests, and makes closing the pane fail after the
+      // first test that renders this form.
+    }
+  });
+
+  function delay() {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+});

--- a/tests/helpers/detail-display-helper.ts
+++ b/tests/helpers/detail-display-helper.ts
@@ -1,0 +1,22 @@
+import type AdvantageState from 'multiattack-5e/components/advantage-state-enum';
+import Damage, { type DamageDetails } from 'multiattack-5e/utils/damage';
+import type { GroupRollDetails } from 'multiattack-5e/utils/dice-groups-and-modifier';
+
+export interface RepeatedTestEventResult {
+  numberOfRepetitions: number;
+  threshold: number;
+  d20Modifier: string;
+  damageList: Damage[];
+  advantageState: AdvantageState;
+  totalDmg: number;
+  totalSuccesses: number;
+  detailsList: TestEventDetails[];
+}
+
+export interface TestEventDetails {
+  roll: GroupRollDetails;
+  success: boolean;
+  majorSuccess: boolean;
+  damage: number;
+  damageDetails: DamageDetails[];
+}

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -210,60 +210,54 @@ module('Integration | Component | detail-display', function (hooks) {
 
     const detailsList = this.element.querySelector(
       '[data-test-detail-list="0"]',
-    )?.children;
-    assert.true(detailsList != null, 'detail list should be present');
+    )!.children;
 
-    if (detailsList) {
-      assert.equal(
-        detailsList.length,
-        3,
-        '3 repetitions should have been displayed',
-      );
+    assert.equal(
+      detailsList.length,
+      3,
+      '3 repetitions should have been displayed',
+    );
 
-      // success 1
-      assert.equal(
-        detailsList[0]?.className,
-        'li-success',
-        'first success should have bullet point formatted as a success',
-      );
-      assert
-        .dom('[data-test-roll-detail="0-0"]')
-        .hasAttribute('title', '1d20: 20 | -1d6: 2')
-        .hasText('21 from roll');
+    // success 1
+    assert.equal(
+      detailsList[0]!.className,
+      'li-success',
+      'first success should have bullet point formatted as a success',
+    );
+    assert
+      .dom('[data-test-roll-detail="0-0"]')
+      .hasAttribute('title', '1d20: 20 | -1d6: 2')
+      .hasText('21 from roll');
 
-      // success 2
-      assert.equal(
-        detailsList[1]?.className,
-        'li-success',
-        'second success should have bullet point formatted as a success',
-      );
-      assert
-        .dom('[data-test-roll-detail="0-1"]')
-        .hasAttribute('title', '1d20: 18 | -1d6: 3')
-        .hasText('18 from roll');
+    // success 2
+    assert.equal(
+      detailsList[1]!.className,
+      'li-success',
+      'second success should have bullet point formatted as a success',
+    );
+    assert
+      .dom('[data-test-roll-detail="0-1"]')
+      .hasAttribute('title', '1d20: 18 | -1d6: 3')
+      .hasText('18 from roll');
 
-      // failure
-      assert.equal(
-        detailsList[2]?.className,
-        'li-fail',
-        'failure should have bullet point formatted as a failure',
-      );
-      assert
-        .dom('[data-test-roll-detail="0-2"]')
-        .hasAttribute('title', '1d20: 1 | -1d6: 6')
-        .hasText('-2 from roll');
-    }
+    // failure
+    assert.equal(
+      detailsList[2]!.className,
+      'li-fail',
+      'failure should have bullet point formatted as a failure',
+    );
+    assert
+      .dom('[data-test-roll-detail="0-2"]')
+      .hasAttribute('title', '1d20: 1 | -1d6: 6')
+      .hasText('-2 from roll');
 
     // Inspect the detailed display of the first success's damage
     const firstDamageDetailsList = this.element.querySelector(
       '[data-test-damage-detail-list="0-0"]',
-    )?.children;
-    assert.true(
-      firstDamageDetailsList != null,
-      'damage detail list should be present',
-    );
+    )!.children;
+
     assert.equal(
-      firstDamageDetailsList?.length,
+      firstDamageDetailsList!.length,
       2,
       '2 types of damage should have been displayed',
     );
@@ -295,13 +289,10 @@ module('Integration | Component | detail-display', function (hooks) {
     // Inspect the detailed display of the second hit's damage
     const secondDamageDetailsList = this.element.querySelector(
       '[data-test-damage-detail-list="0-1"]',
-    )?.children;
-    assert.true(
-      secondDamageDetailsList != null,
-      'damage detail list should be present',
-    );
+    )!.children;
+
     assert.equal(
-      secondDamageDetailsList?.length,
+      secondDamageDetailsList!.length,
       2,
       '2 types of damage should have been displayed',
     );
@@ -507,35 +498,33 @@ module('Integration | Component | detail-display', function (hooks) {
 
     const detailsList1 = this.element.querySelector(
       '[data-test-detail-list="0"]',
-    )?.children;
-    assert.true(detailsList1 != null, 'detail list should be present');
-    if (detailsList1) {
-      assert.equal(
-        detailsList1.length,
-        2,
-        'first event set: 2 events should have been displayed',
-      );
+    )!.children;
 
-      assert.equal(
-        detailsList1[0]?.className,
-        'li-success',
-        'first event set: success should have bullet point formatted as a success',
-      );
-      assert
-        .dom('[data-test-roll-detail="0-0"]')
-        .hasAttribute('title', '1d20: 19')
-        .hasText('16 from roll');
+    assert.equal(
+      detailsList1.length,
+      2,
+      'first event set: 2 events should have been displayed',
+    );
 
-      assert.equal(
-        detailsList1[1]?.className,
-        'li-fail',
-        'first event set: failure should have bullet point formatted as a failure',
-      );
-      assert
-        .dom('[data-test-roll-detail="0-1"]')
-        .hasAttribute('title', '1d20: 2')
-        .hasText('-1 from roll');
-    }
+    assert.equal(
+      detailsList1[0]!.className,
+      'li-success',
+      'first event set: success should have bullet point formatted as a success',
+    );
+    assert
+      .dom('[data-test-roll-detail="0-0"]')
+      .hasAttribute('title', '1d20: 19')
+      .hasText('16 from roll');
+
+    assert.equal(
+      detailsList1[1]!.className,
+      'li-fail',
+      'first event set: failure should have bullet point formatted as a failure',
+    );
+    assert
+      .dom('[data-test-roll-detail="0-1"]')
+      .hasAttribute('title', '1d20: 2')
+      .hasText('-1 from roll');
 
     // Second event set
     assert
@@ -551,25 +540,23 @@ module('Integration | Component | detail-display', function (hooks) {
 
     const detailsList2 = this.element.querySelector(
       '[data-test-detail-list="1"]',
-    )?.children;
-    assert.true(detailsList2 != null, 'detail list should be present');
-    if (detailsList2) {
-      assert.equal(
-        detailsList2.length,
-        1,
-        'second event set: 1 event should have been displayed',
-      );
+    )!.children;
 
-      assert.equal(
-        detailsList2[0]?.className,
-        'li-success',
-        'second event set: success should have bullet point formatted as a success',
-      );
-      assert
-        .dom('[data-test-roll-detail="1-0"]')
-        .hasAttribute('title', '1d20: 12')
-        .hasText('15 from roll');
-    }
+    assert.equal(
+      detailsList2.length,
+      1,
+      'second event set: 1 event should have been displayed',
+    );
+
+    assert.equal(
+      detailsList2[0]!.className,
+      'li-success',
+      'second event set: success should have bullet point formatted as a success',
+    );
+    assert
+      .dom('[data-test-roll-detail="1-0"]')
+      .hasAttribute('title', '1d20: 12')
+      .hasText('15 from roll');
   });
 
   test('it renders damage rolls without dice correctly', async function (this: ElementContext, assert) {
@@ -720,33 +707,30 @@ module('Integration | Component | detail-display', function (hooks) {
 
     const detailsList = this.element.querySelector(
       '[data-test-detail-list="0"]',
-    )?.children;
-    assert.true(detailsList != null, 'detail list should be present');
+    )!.children;
 
-    if (detailsList) {
-      assert.equal(
-        detailsList.length,
-        1,
-        '1 repetition should have been displayed',
-      );
+    assert.equal(
+      detailsList.length,
+      1,
+      '1 repetition should have been displayed',
+    );
 
-      // the roll for the success should have been displayed
-      assert.equal(
-        detailsList[0]?.className,
-        'li-success',
-        'first success should have bullet point formatted as a success',
-      );
-      assert
-        .dom('[data-test-roll-detail="0-0"]')
-        .hasAttribute('title', '1d20: 18')
-        .hasText('21 from roll');
-    }
+    // the roll for the success should have been displayed
+    assert.equal(
+      detailsList[0]!.className,
+      'li-success',
+      'first success should have bullet point formatted as a success',
+    );
+    assert
+      .dom('[data-test-roll-detail="0-0"]')
+      .hasAttribute('title', '1d20: 18')
+      .hasText('21 from roll');
 
     // no damage is associated with this event
     assert.dom('[data-test-damage-detail-list="0-0"]').exists();
     assert.equal(
-      this.element.querySelector('[data-test-damage-detail-list="0-0"]')
-        ?.children.length,
+      this.element.querySelector('[data-test-damage-detail-list="0-0"]')!
+        .children.length,
       0,
       'no damage is present for this event',
     );
@@ -801,7 +785,7 @@ module('Integration | Component | detail-display', function (hooks) {
       .exists('details should be displayed');
 
     assert.equal(
-      this.element.querySelector('[data-test-detail-list="0"]')?.children
+      this.element.querySelector('[data-test-detail-list="0"]')!.children
         .length,
       0,
       'no details are present for this event set',

--- a/tests/unit/utils/repeated-save-test.ts
+++ b/tests/unit/utils/repeated-save-test.ts
@@ -34,7 +34,7 @@ module('Unit | Utils | repeated-save', function (hooks) {
 
       totalDmg: 0,
       totalNumberOfPasses: 1,
-      saveDetailsList: [
+      detailsList: [
         {
           roll: {
             total: 10, // meeting the DC passes the save
@@ -73,7 +73,7 @@ module('Unit | Utils | repeated-save', function (hooks) {
 
       totalDmg: 0,
       totalNumberOfPasses: 0,
-      saveDetailsList: [
+      detailsList: [
         {
           roll: {
             total: 6,
@@ -119,7 +119,7 @@ module('Unit | Utils | repeated-save', function (hooks) {
 
       totalDmg: 0,
       totalNumberOfPasses: 2,
-      saveDetailsList: [
+      detailsList: [
         {
           roll: {
             total: 6,


### PR DESCRIPTION
This adds support for repeated (identical) saving throws, which will be valuable when a player character attacks a group of enemies with an area-of-effect attack or, potentially, if a horde of enemies attack a player character with attacks requiring saving throws. Both the backend class and the front-end form for saving throws are very similar, though not identical, to those for repeated attacks; this pull request extracts common code into new classes and components. The detail-display component is rewritten to use input functions for its labels, allowing the same Handlebars code to alternate between "Target AC" and "Save DC" (for instance).

This also improves the tests for the repeated attack form to test more comprehensively, as well as moving some tests from the detail-display tests into the repeated-attack-form tests due to the rewrite. 

Damage from saving throws is not yet implemented, although the UI exposes it. This will be implemented shortly, but is currently omitted to reduce the number of changes in this PR.