### PR TITLE
Implement damage for saving throws

### DIFF
--- a/app/components/detail-damage-display.hbs
+++ b/app/components/detail-damage-display.hbs
@@ -1,0 +1,34 @@
+<ul data-test-damage-detail-list="{{@index}}-{{@index2}}">
+  {{#each @damageDetails as |damage index3|}}
+  <li>
+    <span data-test-damage-roll-detail="{{@index}}-{{@index2}}-{{index3}}"
+      title="{{@getRollDetailString damage.details.roll.rolls}}">
+      {{#if damage.details.roll.rolls}}
+      <a data-test-damage-roll-collapse-link="{{@index}}-{{@index2}}-{{index3}}" class="link link-dark collapsed"
+        data-bs-toggle="collapse" href="#damage-detail-collapse-{{@index}}-{{@index2}}-{{index3}}" role="button"
+        aria-expanded="false"
+        aria-controls="damage-detail-collapse-{{@index}}-{{@index2}}-{{index3}}">{{damage.inflicted}}</a>
+      {{/if}}
+      {{#unless damage.details.roll.rolls}}
+      {{damage.inflicted}}
+      {{/unless}}
+      {{damage.details.type}} damage
+      {{#if (@shouldBoldDice @setDetails)}} (<b>{{damage.details.dice}}</b>){{/if}}
+      {{#unless (@shouldBoldDice @setDetails)}} ({{damage.details.dice}}){{/unless}}
+      {{#if damage.details.resisted}} (resisted){{/if}}
+      {{#if damage.details.vulnerable}} (vulnerable){{/if}}
+    </span>
+
+    <div data-test-damage-roll-collapse-pane="{{@index}}-{{@index2}}-{{index3}}" class="collapse"
+      id="damage-detail-collapse-{{@index}}-{{@index2}}-{{index3}}">
+      <ul>
+        {{#each damage.details.roll.rolls as |roll|}}
+        <li class="text-muted">
+          {{roll.name}}: {{@getStringWithSpaces roll.rolls}}
+        </li>
+        {{/each}}
+      </ul>
+    </div>
+  </li>
+  {{/each}}
+</ul>

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -5,8 +5,7 @@
     </h2>
   </div>
   <div class="col col-sm-4 d-flex justify-content-end">
-    <button class="btn btn-danger btn-sm" type="button" {{on "click" @clearLog}}
-      data-test-button-clear-log>
+    <button class="btn btn-danger btn-sm" type="button" {{on "click" @clearLog}} data-test-button-clear-log>
       Clear
     </button>
   </div>
@@ -40,8 +39,7 @@
 
         {{#if (@isSuccess details) }}
         <li class="li-success">
-          <span data-test-roll-detail="{{index}}-{{index2}}"
-            title="{{this.getRollDetailString details.roll.rolls}}">
+          <span data-test-roll-detail="{{index}}-{{index2}}" title="{{this.getRollDetailString details.roll.rolls}}">
             <a data-test-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
               data-bs-toggle="collapse" href="#roll-detail-collapse-{{index}}-{{index2}}" role="button"
               aria-expanded="false" aria-controls="roll-detail-collapse-{{index}}-{{index2}}">
@@ -58,47 +56,15 @@
             </ul>
           </div>
 
-          <ul data-test-damage-detail-list="{{index}}-{{index2}}">
-            {{#each details.damageDetails as |damage index3|}}
-            <li>
-              <span data-test-damage-roll-detail="{{index}}-{{index2}}-{{index3}}"
-                title="{{this.getRollDetailString damage.roll.rolls}}">
-                {{#if damage.roll.rolls}}
-                <a data-test-damage-roll-collapse-link="{{index}}-{{index2}}-{{index3}}"
-                  class="link link-dark collapsed" data-bs-toggle="collapse"
-                  href="#damage-detail-collapse-{{index}}-{{index2}}-{{index3}}" role="button" aria-expanded="false"
-                  aria-controls="damage-detail-collapse-{{index}}-{{index2}}-{{index3}}">{{damage.roll.total}}</a>
-                {{/if}}
-                {{#unless damage.roll.rolls}}
-                {{damage.roll.total}}
-                {{/unless}}
-                {{damage.type}} damage
-                {{#if (@shouldBoldDice details)}} (<b>{{damage.dice}}</b>){{/if}}
-                {{#unless (@shouldBoldDice details)}} ({{damage.dice}}){{/unless}}
-                {{#if damage.resisted}} (resisted){{/if}}
-                {{#if damage.vulnerable}} (vulnerable){{/if}}
-              </span>
-
-              <div data-test-damage-roll-collapse-pane="{{index}}-{{index2}}-{{index3}}" class="collapse"
-                id="damage-detail-collapse-{{index}}-{{index2}}-{{index3}}">
-                <ul>
-                  {{#each damage.roll.rolls as |roll|}}
-                  <li class="text-muted">
-                    {{roll.name}}: {{this.getStringWithSpaces roll.rolls}}
-                  </li>
-                  {{/each}}
-                </ul>
-              </div>
-            </li>
-            {{/each}}
-          </ul>
+          <DetailDamageDisplay @damageDetails={{details.damageDetails}} @index={{index}} @index2={{index2}}
+            @getRollDetailString={{this.getRollDetailString}} @shouldBoldDice={{@shouldBoldDice}}
+            @setDetails={{details}} @getStringWithSpaces={{this.getStringWithSpaces}} />
         </li>
         {{/if}}
 
         {{#unless (@isSuccess details) }}
         <li class="li-fail">
-          <span data-test-roll-detail="{{index}}-{{index2}}"
-            title="{{this.getRollDetailString details.roll.rolls}}">
+          <span data-test-roll-detail="{{index}}-{{index2}}" title="{{this.getRollDetailString details.roll.rolls}}">
             <a data-test-roll-collapse-link="{{index}}-{{index2}}" class="link link-dark collapsed"
               data-bs-toggle="collapse" href="#roll-detail-collapse-{{index}}-{{index2}}" role="button"
               aria-expanded="false" aria-controls="roll-detail-collapse-{{index}}-{{index2}}">
@@ -114,6 +80,10 @@
               {{/each}}
             </ul>
           </div>
+
+          <DetailDamageDisplay @damageDetails={{details.damageDetails}} @index={{index}} @index2={{index2}}
+            @getRollDetailString={{this.getRollDetailString}} @shouldBoldDice={{@shouldBoldDice}}
+            @setDetails={{details}} @getStringWithSpaces={{this.getStringWithSpaces}} />
         </li>
         {{/unless}}
 

--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -41,6 +41,23 @@
 
       <hr>
 
+      <div class="form-check">
+        <Input data-test-input-half-damage class="form-check-input" @type="checkbox"
+          id="saveForHalfDamage" name="saveForHalfDamage" @checked={{this.saveForHalfDamage}} />
+        <label class="form-check-label" for="saveForHalfDamage">
+          Save for half damage
+        </label>
+      </div>
+      {{!-- <div class="form-check">
+        <Input data-test-input-roll-dmg-every-save class="form-check-input" @type="checkbox" id="rollDamageEverySave"
+          name="rollDamageEverySave" @checked={{this.rollDamageEverySave}} />
+        <label class="form-check-label" for="rollDamageEverySave">
+          Roll new damage with every save
+        </label>
+      </div> --}}
+
+      <hr>
+
       <DamagePane @damageList={{this.damageList}} @removeDamageType={{this.removeDamageType}}
         @addNewDamageType={{this.addNewDamageType}} />
 
@@ -55,7 +72,7 @@
     <DetailDisplay @log={{this.saveResultLog}} @clearLog={{this.clearSaveLog}} @getLogHeader={{this.getLogHeader}}
       @getSuccessCountString={{this.getPassCountString}} @getRepCountString={{this.getSaveCountString}}
       @getThresholdString={{this.getSaveDCString}} @getD20Modifier={{this.getSaveModifier}}
-      @getRollString={{this.getSavingThrowString}} @isSuccess={{this.isPass}} @getD20RollString={{this.getD20RollString}}
-      @shouldBoldDice={{this.shouldBoldDice}} />
+      @getRollString={{this.getSavingThrowString}} @isSuccess={{this.isPass}}
+      @getD20RollString={{this.getD20RollString}} @shouldBoldDice={{this.shouldBoldDice}} />
   </div>
 </div>

--- a/app/utils/attack.ts
+++ b/app/utils/attack.ts
@@ -2,7 +2,8 @@ import type AdvantageState from 'multiattack-5e/components/advantage-state-enum'
 import type RandomnessService from 'multiattack-5e/services/randomness';
 
 import D20WithModifiers from './d20-with-modifiers';
-import Damage, { type DamageDetails } from './damage';
+import Damage from './damage';
+import { type InflictedDamageDetails } from './damage-details';
 import { type GroupRollDetails } from './dice-groups-and-modifier';
 
 export interface AttackDetails {
@@ -12,7 +13,7 @@ export interface AttackDetails {
   nat1: boolean;
   damage: number;
   numberOfHits: number;
-  damageDetails: DamageDetails[];
+  damageDetails: InflictedDamageDetails[];
 }
 
 export default class Attack {
@@ -57,7 +58,7 @@ export default class Attack {
 
     let totalDmg = 0;
     let numberOfHits = 0;
-    const damageDetails: DamageDetails[] = [];
+    const damageDetails: InflictedDamageDetails[] = [];
 
     // Attacks always miss on a nat1, always hit on a crit, and otherwise hit if
     // the roll equals or exceeds the target AC.
@@ -66,8 +67,11 @@ export default class Attack {
       numberOfHits += 1;
       for (const damage of this.damageTypes) {
         const dmg = damage.roll(crit);
-        totalDmg += dmg.roll.total;
-        damageDetails.push(dmg);
+        totalDmg += dmg.getInflictedDamage();
+        damageDetails.push({
+          inflicted: dmg.getInflictedDamage(),
+          details: dmg,
+        });
       }
     }
 

--- a/app/utils/damage-details.ts
+++ b/app/utils/damage-details.ts
@@ -1,0 +1,62 @@
+import { type GroupRollDetails } from './dice-groups-and-modifier';
+
+/**
+ * An interface pairing the damage inflicted in a specific context with the
+ * associated damage details. This will be used for attacks or saves to display
+ * the details of inflicted damage.
+ */
+export interface InflictedDamageDetails {
+  inflicted: number;
+  details: DamageDetails;
+}
+
+export class DamageDetails {
+  type: string;
+  dice: string;
+  roll: GroupRollDetails;
+  resisted: boolean;
+  vulnerable: boolean;
+
+  constructor(
+    type: string,
+    dice: string,
+    roll: GroupRollDetails,
+    resisted: boolean,
+    vulnerable: boolean,
+  ) {
+    this.type = type;
+    this.dice = dice;
+    this.roll = roll;
+    this.resisted = resisted;
+    this.vulnerable = vulnerable;
+  }
+
+  /**
+   * Get the total damage inflicted by the dice rolls for this class. This
+   * applies resistance, vulnerability, and optionally an additional specified
+   * modifier to the damage rolled on the dice, in the order (modifier,
+   * resistance, vulnerability). This means that if some other factor affects
+   * the amount of damage inflicted, such as passing a save against a
+   * save-for-half spell like Fireball, that alteration is applied before
+   * resistance and vulnerability.
+   * @param [multiplier = 1] an optional multiplier which should be applied to
+   * the total rolled damage before resistance or vulnerability
+   */
+  getInflictedDamage(multiplier = 1): number {
+    let inflicted = this.roll.total;
+
+    // Apply the input multiplier on the damage (which will default to 1).
+    // Round down in case the multiplier is fractional.
+    inflicted = Math.floor(inflicted * multiplier);
+
+    if (this.resisted) {
+      inflicted = Math.floor(inflicted / 2);
+    }
+
+    if (this.vulnerable) {
+      inflicted = inflicted * 2;
+    }
+
+    return inflicted;
+  }
+}

--- a/app/utils/damage.ts
+++ b/app/utils/damage.ts
@@ -4,18 +4,9 @@ import { tracked } from '@glimmer/tracking';
 
 import type RandomnessService from 'multiattack-5e/services/randomness';
 
-import DiceGroupsAndModifier, {
-  type GroupRollDetails,
-} from './dice-groups-and-modifier';
+import { DamageDetails } from './damage-details';
+import DiceGroupsAndModifier from './dice-groups-and-modifier';
 import DiceStringParser from './dice-string-parser';
-
-export interface DamageDetails {
-  type: string;
-  dice: string;
-  roll: GroupRollDetails;
-  resisted: boolean;
-  vulnerable: boolean;
-}
 
 export default class Damage {
   @tracked type: string;
@@ -132,23 +123,13 @@ export default class Damage {
     // negative damage modifier)
     damageRoll.total = Math.max(damageRoll.total, 0);
 
-    // Take resistance and vulnerability (which are not mutually exclusive)
-    // into account.
-    if (this.targetResistant) {
-      damageRoll.total = Math.floor(damageRoll.total / 2);
-    }
-
-    if (this.targetVulnerable) {
-      damageRoll.total = damageRoll.total * 2;
-    }
-
-    return {
-      type: this.type,
-      dice: this.damage.prettyString(crit),
-      roll: damageRoll,
-      resisted: this.targetResistant,
-      vulnerable: this.targetVulnerable,
-    };
+    return new DamageDetails(
+      this.type,
+      this.damage.prettyString(crit),
+      damageRoll,
+      this.targetResistant,
+      this.targetVulnerable,
+    );
   }
 
   /**

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -69,7 +69,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       .dom('#nav-attacks [data-test-detail-list="0"]')
       .isVisible('individual attack details should be displayed');
 
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('#nav-attacks [data-test-detail-list="0"]')!
         .children.length,
       8,
@@ -111,7 +111,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       .dom('#nav-attacks [data-test-detail-list="0"]')
       .isVisible('attack details should be displayed for the second attack');
 
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('#nav-attacks [data-test-detail-list="0"]')!
         .children.length,
       4,
@@ -132,7 +132,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       .dom('#nav-attacks [data-test-detail-list="1"]')
       .isVisible('attack details should be displayed for the first attack');
 
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('#nav-attacks [data-test-detail-list="1"]')!
         .children.length,
       8,

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -183,41 +183,6 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         .hasAttribute('title', '1d20: 1 | -1d6: 1')
         .hasText('3 to hit (NAT 1!)');
 
-      // Test the collapsible attack-roll details
-      assert
-        .dom(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`)
-        .hasAria('expanded', 'false')
-        .hasText('3');
-      assert
-        .dom(`#nav-attacks [data-test-roll-collapse-pane="0-${i}"]`)
-        .hasText('1d20: 1 -1d6: 1')
-        .doesNotHaveClass(
-          'show',
-          'attack roll detail pane should start collapsed',
-        );
-
-      // The attack roll details should be visible after a click
-      await click(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`);
-      // Delay briefly so that the pane finishes opening
-      await delay();
-      assert
-        .dom(`#nav-attacks [data-test-roll-collapse-link="0-${i}"]`)
-        .hasAria(
-          'expanded',
-          'true',
-          'after click, attack roll detail pane should be expanded',
-        );
-      assert
-        .dom(`#nav-attacks [data-test-roll-collapse-pane="0-${i}"]`)
-        .hasClass(
-          'show',
-          'after click, attack roll detail pane should be visible',
-        );
-
-      // Do not test closing the pane; some sort of state appears to persist in
-      // Bootstrap between tests, and makes closing the pane fail after the
-      // first test that renders this form.
-
       // The damage section should be empty
       assert
         .dom(`#nav-attacks [data-test-damage-roll-detail="0-${i}-0"]`)
@@ -382,7 +347,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
       .dom(`#nav-attacks [data-test-damage-roll-detail="0-0-0"]`)
       .doesNotExist();
 
-    // Inspect the first attack's details
+    // Inspect the second set of attack's details
     assert
       .dom('#nav-attacks [data-test-data-list="1"]')
       .hasText(

--- a/tests/acceptance/repeated-save-form-test.ts
+++ b/tests/acceptance/repeated-save-form-test.ts
@@ -53,7 +53,7 @@ module('Acceptance | repeated save form', function (hooks) {
       .dom('#nav-saves [data-test-detail-list="0"]')
       .isVisible('individual save details should be displayed');
 
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('#nav-saves [data-test-detail-list="0"]')!
         .children.length,
       8,
@@ -96,7 +96,7 @@ module('Acceptance | repeated save form', function (hooks) {
       .dom('#nav-saves [data-test-detail-list="0"]')
       .isVisible('save details should be displayed for the second save');
 
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('#nav-saves [data-test-detail-list="0"]')!
         .children.length,
       4,
@@ -117,7 +117,7 @@ module('Acceptance | repeated save form', function (hooks) {
       .dom('#nav-saves [data-test-detail-list="1"]')
       .isVisible('save details should be displayed for the first save');
 
-    assert.equal(
+    assert.strictEqual(
       this.element.querySelector('#nav-saves [data-test-detail-list="1"]')!
         .children.length,
       8,

--- a/tests/acceptance/repeated-save-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-save-form-with-fakes-test.ts
@@ -1,8 +1,9 @@
-import { click, fillIn, visit } from '@ember/test-helpers';
+import { click, fillIn, select, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import DamageType from 'multiattack-5e/components/damage-type-enum';
 import type RandomnessService from 'multiattack-5e/services/randomness';
 
 import { type ElementContext } from '../types/element-context';
@@ -22,6 +23,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-numberOfSaves]', '1');
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-1D4');
+    await fillIn('#nav-saves [data-test-input-damage="0"]', '2d6');
 
     // Roll the saves
     await click('#nav-saves [data-test-button-rollSaves]');
@@ -33,7 +35,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
         'the details for the set of saves should be displayed',
       );
 
-    // Saves do not yet inflict damage
+    // Since save-for-half was not checked, this save inflicts 0 damage
     assert
       .dom('#nav-saves [data-test-total-damage-header="0"]')
       .hasText('Total Damage: 0 (1 pass)');
@@ -43,7 +45,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
       '[data-test-detail-list="0"]',
     )!.children;
 
-    assert.equal(
+    assert.strictEqual(
       detailsList[0]?.className,
       'li-success',
       'saving throw should have bullet point formatted as a success',
@@ -103,6 +105,11 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-numberOfSaves]', '3');
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '1d6+3');
+    await fillIn('#nav-saves [data-test-input-damage="0"]', '2d6');
+    await select(
+      '#nav-saves [data-test-damage-dropdown="0"]',
+      DamageType.COLD.name,
+    );
 
     // Roll the saves
     await click('#nav-saves [data-test-button-rollSaves]');
@@ -114,10 +121,10 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
         'the details for the set of saves should be displayed',
       );
 
-    // Saves do not yet inflict damage
+    // All three saves failed, inflicting full damage but with minimized dice
     assert
       .dom('#nav-saves [data-test-total-damage-header="0"]')
-      .hasText('Total Damage: 0 (0 passes)');
+      .hasText('Total Damage: 6 (0 passes)');
 
     // Check that the displayed text matches the expected die rolls. Since all
     // dice are minimized, the three saves are identical.
@@ -126,8 +133,8 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     )!.children;
 
     for (let i = 0; i < 3; i++) {
-      assert.equal(
-        detailsList[0]?.className,
+      assert.strictEqual(
+        detailsList[i]?.className,
         'li-fail',
         'saving throw should have bullet point formatted as a failure',
       );
@@ -138,35 +145,43 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
         .hasAttribute('title', '1d20: 1 | 1d6: 1')
         .hasText('5 to save');
 
-      // Test the collapsible saving throw details
+      // Examine the damage section
       assert
-        .dom(`#nav-saves [data-test-roll-collapse-link="0-${i}"]`)
+        .dom(`#nav-saves [data-test-damage-roll-detail="0-${i}-0"]`)
+        .hasAttribute('title', '2d6: 1, 1')
+        .hasText('2 cold damage (2d6)');
+
+      // Test the collapsible damage pane
+      assert
+        .dom(`#nav-saves [data-test-damage-roll-collapse-link="0-${i}-0"]`)
         .hasAria('expanded', 'false')
-        .hasText('5');
+        .hasText('2');
       assert
-        .dom(`#nav-saves [data-test-roll-collapse-pane="0-${i}"]`)
-        .hasText('1d20: 1 1d6: 1')
+        .dom(`#nav-saves [data-test-damage-roll-collapse-pane="0-${i}-0"]`)
+        .hasText('2d6: 1, 1')
         .doesNotHaveClass(
           'show',
-          'saving throw detail pane should start collapsed',
+          'damage roll detail pane should start collapsed',
         );
 
-      // The saving throw roll details should be visible after a click
-      await click(`#nav-saves [data-test-roll-collapse-link="0-${i}"]`);
+      // The damage roll details should be visible after a click
+      await click(
+        `#nav-saves [data-test-damage-roll-collapse-link="0-${i}-0"]`,
+      );
       // Delay briefly so that the pane finishes opening
       await delay();
       assert
-        .dom(`#nav-saves [data-test-roll-collapse-link="0-${i}"]`)
+        .dom(`#nav-saves [data-test-damage-roll-collapse-link="0-${i}-0"]`)
         .hasAria(
           'expanded',
           'true',
-          'after click, saving throw roll detail pane should be expanded',
+          'after click, damage roll detail pane should be expanded',
         );
       assert
-        .dom(`#nav-saves [data-test-roll-collapse-pane="0-${i}"]`)
+        .dom(`#nav-saves [data-test-damage-roll-collapse-pane="0-${i}-0"]`)
         .hasClass(
           'show',
-          'after click, saving throw roll detail pane should be visible',
+          'after click, damage roll detail pane should be visible',
         );
 
       // Do not test closing the pane; some sort of state appears to persist in

--- a/tests/helpers/detail-display-helper.ts
+++ b/tests/helpers/detail-display-helper.ts
@@ -1,5 +1,6 @@
 import type AdvantageState from 'multiattack-5e/components/advantage-state-enum';
-import Damage, { type DamageDetails } from 'multiattack-5e/utils/damage';
+import Damage from 'multiattack-5e/utils/damage';
+import { type InflictedDamageDetails } from 'multiattack-5e/utils/damage-details';
 import type { GroupRollDetails } from 'multiattack-5e/utils/dice-groups-and-modifier';
 
 export interface RepeatedTestEventResult {
@@ -18,5 +19,5 @@ export interface TestEventDetails {
   success: boolean;
   majorSuccess: boolean;
   damage: number;
-  damageDetails: DamageDetails[];
+  damageDetails: InflictedDamageDetails[];
 }

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -61,38 +61,44 @@ module('Integration | Component | detail-display', function (hooks) {
             damage: 37,
             damageDetails: [
               {
-                type: 'piercing',
-                dice: '4d6 + 2d4 + 5',
-                roll: {
-                  total: 11,
-                  rolls: [
-                    {
-                      name: '4d6',
-                      rolls: [4, 5, 2, 2],
-                    },
-                    {
-                      name: '2d4',
-                      rolls: [3, 2],
-                    },
-                  ],
+                inflicted: 11,
+                details: {
+                  type: 'piercing',
+                  dice: '4d6 + 2d4 + 5',
+                  roll: {
+                    total: 11,
+                    rolls: [
+                      {
+                        name: '4d6',
+                        rolls: [4, 5, 2, 2],
+                      },
+                      {
+                        name: '2d4',
+                        rolls: [3, 2],
+                      },
+                    ],
+                  },
+                  resisted: true,
+                  vulnerable: false,
                 },
-                resisted: true,
-                vulnerable: false,
               },
               {
-                type: 'radiant',
-                dice: '4d8',
-                roll: {
-                  total: 26,
-                  rolls: [
-                    {
-                      name: '4d8',
-                      rolls: [2, 7, 1, 3],
-                    },
-                  ],
+                inflicted: 26,
+                details: {
+                  type: 'radiant',
+                  dice: '4d8',
+                  roll: {
+                    total: 26,
+                    rolls: [
+                      {
+                        name: '4d8',
+                        rolls: [2, 7, 1, 3],
+                      },
+                    ],
+                  },
+                  resisted: false,
+                  vulnerable: true,
                 },
-                resisted: false,
-                vulnerable: true,
               },
             ],
           },
@@ -115,38 +121,44 @@ module('Integration | Component | detail-display', function (hooks) {
             damage: 25,
             damageDetails: [
               {
-                type: 'piercing',
-                dice: '2d6 + 1d4 + 5',
-                roll: {
-                  total: 5,
-                  rolls: [
-                    {
-                      name: '2d6',
-                      rolls: [2, 1],
-                    },
-                    {
-                      name: '1d4',
-                      rolls: [2],
-                    },
-                  ],
+                inflicted: 5,
+                details: {
+                  type: 'piercing',
+                  dice: '2d6 + 1d4 + 5',
+                  roll: {
+                    total: 10,
+                    rolls: [
+                      {
+                        name: '2d6',
+                        rolls: [2, 1],
+                      },
+                      {
+                        name: '1d4',
+                        rolls: [2],
+                      },
+                    ],
+                  },
+                  resisted: true,
+                  vulnerable: false,
                 },
-                resisted: true,
-                vulnerable: false,
               },
               {
-                type: 'radiant',
-                dice: '2d8',
-                roll: {
-                  total: 20,
-                  rolls: [
-                    {
-                      name: '2d8',
-                      rolls: [3, 7],
-                    },
-                  ],
+                inflicted: 20,
+                details: {
+                  type: 'radiant',
+                  dice: '2d8',
+                  roll: {
+                    total: 10,
+                    rolls: [
+                      {
+                        name: '2d8',
+                        rolls: [3, 7],
+                      },
+                    ],
+                  },
+                  resisted: false,
+                  vulnerable: true,
                 },
-                resisted: false,
-                vulnerable: true,
               },
             ],
           },
@@ -363,38 +375,44 @@ module('Integration | Component | detail-display', function (hooks) {
             damage: 15,
             damageDetails: [
               {
-                type: 'piercing',
-                dice: '2d6 + 1d4 + 5',
-                roll: {
-                  total: 5,
-                  rolls: [
-                    {
-                      name: '2d6',
-                      rolls: [2, 1],
-                    },
-                    {
-                      name: '1d4',
-                      rolls: [2],
-                    },
-                  ],
+                inflicted: 5,
+                details: {
+                  type: 'piercing',
+                  dice: '2d6 + 1d4 + 5',
+                  roll: {
+                    total: 10,
+                    rolls: [
+                      {
+                        name: '2d6',
+                        rolls: [2, 1],
+                      },
+                      {
+                        name: '1d4',
+                        rolls: [2],
+                      },
+                    ],
+                  },
+                  resisted: true,
+                  vulnerable: false,
                 },
-                resisted: true,
-                vulnerable: false,
               },
               {
-                type: 'radiant',
-                dice: '2d8',
-                roll: {
-                  total: 10,
-                  rolls: [
-                    {
-                      name: '2d8',
-                      rolls: [2, 8],
-                    },
-                  ],
+                inflicted: 10,
+                details: {
+                  type: 'radiant',
+                  dice: '2d8',
+                  roll: {
+                    total: 10,
+                    rolls: [
+                      {
+                        name: '2d8',
+                        rolls: [2, 8],
+                      },
+                    ],
+                  },
+                  resisted: false,
+                  vulnerable: false,
                 },
-                resisted: false,
-                vulnerable: false,
               },
             ],
           },
@@ -446,19 +464,22 @@ module('Integration | Component | detail-display', function (hooks) {
             damage: 10,
             damageDetails: [
               {
-                type: 'acid',
-                dice: '3d6',
-                roll: {
-                  total: 10,
-                  rolls: [
-                    {
-                      name: '3d6',
-                      rolls: [2, 5, 4],
-                    },
-                  ],
+                inflicted: 10,
+                details: {
+                  type: 'acid',
+                  dice: '3d6',
+                  roll: {
+                    total: 11,
+                    rolls: [
+                      {
+                        name: '3d6',
+                        rolls: [2, 5, 4],
+                      },
+                    ],
+                  },
+                  resisted: true,
+                  vulnerable: true,
                 },
-                resisted: true,
-                vulnerable: true,
               },
             ],
           },
@@ -593,14 +614,17 @@ module('Integration | Component | detail-display', function (hooks) {
             damage: 60,
             damageDetails: [
               {
-                type: 'force',
-                dice: '60',
-                roll: {
-                  total: 60,
-                  rolls: [],
+                inflicted: 60,
+                details: {
+                  type: 'force',
+                  dice: '60',
+                  roll: {
+                    total: 60,
+                    rolls: [],
+                  },
+                  resisted: false,
+                  vulnerable: false,
                 },
-                resisted: false,
-                vulnerable: false,
               },
             ],
           },

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -6,7 +6,8 @@ import AdvantageState from 'multiattack-5e/components/advantage-state-enum';
 import DamageType from 'multiattack-5e/components/damage-type-enum';
 import RandomnessService from 'multiattack-5e/services/randomness';
 import Attack from 'multiattack-5e/utils/attack';
-import Damage, { type DamageDetails } from 'multiattack-5e/utils/damage';
+import Damage from 'multiattack-5e/utils/damage';
+import { DamageDetails } from 'multiattack-5e/utils/damage-details';
 
 module('Unit | Utils | attack', function (hooks) {
   setupTest(hooks);
@@ -147,8 +148,10 @@ module('Unit | Utils | attack', function (hooks) {
     attack.attackDie.getD20Roll = fakeD20;
 
     // Fake the results of the damage dice
-    const fakePiercingDamageDetails = {
-      roll: {
+    const fakePiercingDamageDetails = new DamageDetails(
+      DamageType.PIERCING.name,
+      '2d6 + 1d4 + 5',
+      {
         total: 13,
         rolls: [
           {
@@ -161,15 +164,15 @@ module('Unit | Utils | attack', function (hooks) {
           },
         ],
       },
-      type: DamageType.PIERCING.name,
-      dice: '2d6 + 1d4 + 5',
-      resisted: false,
-      vulnerable: false,
-    };
+      false,
+      false,
+    );
     const fakePiercing = sinon.fake.returns(fakePiercingDamageDetails);
 
-    const fakeRadiantDamageDetails = {
-      roll: {
+    const fakeRadiantDamageDetails = new DamageDetails(
+      DamageType.RADIANT.name,
+      '2d8',
+      {
         total: 7,
         rolls: [
           {
@@ -178,22 +181,13 @@ module('Unit | Utils | attack', function (hooks) {
           },
         ],
       },
-      type: DamageType.RADIANT.name,
-      dice: '2d8',
-      resisted: false,
-      vulnerable: false,
-    };
+      false,
+      false,
+    );
     const fakeRadiant = sinon.fake.returns(fakeRadiantDamageDetails);
 
-    const piercing: Damage | undefined = attack.damageTypes[0];
-    if (piercing) {
-      piercing.roll = fakePiercing;
-    }
-
-    const radiant: Damage | undefined = attack.damageTypes[1];
-    if (radiant) {
-      radiant.roll = fakeRadiant;
-    }
+    attack.damageTypes[0]!.roll = fakePiercing;
+    attack.damageTypes[1]!.roll = fakeRadiant;
 
     const attackData = attack.makeAttack(15);
     fakePiercing.alwaysCalledWith(false);
@@ -211,14 +205,16 @@ module('Unit | Utils | attack', function (hooks) {
       20,
       '20 damage should have been inflicted',
     );
-    const expectedDmg: DamageDetails[] = [
-      fakePiercingDamageDetails,
-      fakeRadiantDamageDetails,
-    ];
+
     assert.deepEqual(
-      attackData.damageDetails,
-      expectedDmg,
-      'damage details should match expectations',
+      attackData.damageDetails[0]?.details,
+      fakePiercingDamageDetails,
+      'piercing damage details should match expectations',
+    );
+    assert.deepEqual(
+      attackData.damageDetails[1]?.details,
+      fakeRadiantDamageDetails,
+      'radiant damage details should match expectations',
     );
   });
 
@@ -243,8 +239,10 @@ module('Unit | Utils | attack', function (hooks) {
     attack.attackDie.getD20Roll = fakeD20;
 
     // Fake the results of the damage dice
-    const fakePiercingDamageDetails = {
-      roll: {
+    const fakePiercingDamageDetails = new DamageDetails(
+      DamageType.PIERCING.name,
+      '4d6 + 2d4 + 5',
+      {
         total: 25,
         rolls: [
           {
@@ -257,15 +255,15 @@ module('Unit | Utils | attack', function (hooks) {
           },
         ],
       },
-      type: DamageType.PIERCING.name,
-      dice: '4d6 + 2d4 + 5',
-      resisted: false,
-      vulnerable: false,
-    };
+      false,
+      false,
+    );
     const fakePiercing = sinon.fake.returns(fakePiercingDamageDetails);
 
-    const fakeRadiantDamageDetails = {
-      roll: {
+    const fakeRadiantDamageDetails = new DamageDetails(
+      DamageType.PIERCING.name,
+      '4d8',
+      {
         total: 14,
         rolls: [
           {
@@ -274,22 +272,13 @@ module('Unit | Utils | attack', function (hooks) {
           },
         ],
       },
-      type: DamageType.PIERCING.name,
-      dice: '4d8',
-      resisted: false,
-      vulnerable: false,
-    };
+      false,
+      false,
+    );
     const fakeRadiant = sinon.fake.returns(fakeRadiantDamageDetails);
 
-    const piercing: Damage | undefined = attack.damageTypes[0];
-    if (piercing) {
-      piercing.roll = fakePiercing;
-    }
-
-    const radiant: Damage | undefined = attack.damageTypes[1];
-    if (radiant) {
-      radiant.roll = fakeRadiant;
-    }
+    attack.damageTypes[0]!.roll = fakePiercing;
+    attack.damageTypes[1]!.roll = fakeRadiant;
 
     const attackData = attack.makeAttack(25);
     fakePiercing.alwaysCalledWith(true);
@@ -310,14 +299,16 @@ module('Unit | Utils | attack', function (hooks) {
       39,
       '39 damage should have been inflicted (25 + 14)',
     );
-    const expectedDmg: DamageDetails[] = [
-      fakePiercingDamageDetails,
-      fakeRadiantDamageDetails,
-    ];
+
     assert.deepEqual(
-      attackData.damageDetails,
-      expectedDmg,
-      'damage details should match expectations',
+      attackData.damageDetails[0]?.details,
+      fakePiercingDamageDetails,
+      'piercing damage details should match expectations',
+    );
+    assert.deepEqual(
+      attackData.damageDetails[1]?.details,
+      fakeRadiantDamageDetails,
+      'radiant damage details should match expectations',
     );
   });
 });

--- a/tests/unit/utils/damage-details-test.ts
+++ b/tests/unit/utils/damage-details-test.ts
@@ -1,0 +1,147 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import DamageType from 'multiattack-5e/components/damage-type-enum';
+import { DamageDetails } from 'multiattack-5e/utils/damage-details';
+
+module('Unit | Utils | damage-details', function (hooks) {
+  setupTest(hooks);
+
+  test('it halves damage for resistant targets', async function (assert) {
+    const details = new DamageDetails(
+      DamageType.RADIANT.name,
+      '2d6 + 1',
+      {
+        total: 9,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
+      true,
+      false,
+    );
+    assert.equal(
+      details.getInflictedDamage(),
+      4,
+      'roll should inflict (3 + 5 + 1) / 2 = 4 total damage',
+    );
+  });
+
+  test('it doubles damage for vulnerable targets', async function (assert) {
+    const details = new DamageDetails(
+      DamageType.RADIANT.name,
+      '2d6 + 1',
+      {
+        total: 9,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
+      false,
+      true,
+    );
+    assert.equal(
+      details.getInflictedDamage(),
+      18,
+      'roll should inflict (3 + 5 + 1) * 2 = 18 total damage',
+    );
+  });
+
+  test('it halves, then doubles, damage for resistant and vulnerable targets', async function (assert) {
+    const details = new DamageDetails(
+      DamageType.RADIANT.name,
+      '2d6 + 1',
+      {
+        total: 9,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
+      true,
+      true,
+    );
+    assert.equal(
+      details.getInflictedDamage(),
+      8,
+      'roll should inflict ((3 + 5 + 1) / 2) * 2 = 8 total damage',
+    );
+  });
+
+  test('it applies a fractional input modifier', async function (assert) {
+    const details = new DamageDetails(
+      DamageType.RADIANT.name,
+      '2d6 + 1',
+      {
+        total: 9,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
+      false,
+      false,
+    );
+    assert.equal(
+      details.getInflictedDamage(0.9),
+      8,
+      'roll should inflict (3 + 5 + 1) * 0.9 = 8 total damage',
+    );
+  });
+
+  test('it applies an input modifier before applying resistance', async function (assert) {
+    const details = new DamageDetails(
+      DamageType.RADIANT.name,
+      '1d4',
+      {
+        total: 1,
+        rolls: [
+          {
+            name: '1d4',
+            rolls: [1],
+          },
+        ],
+      },
+      true,
+      false,
+    );
+    assert.equal(
+      details.getInflictedDamage(2),
+      1,
+      'roll should inflict floor(1 * 2) / 2 = 1 damage, not floor(1 / 2) * 2 = 0 damage',
+    );
+  });
+
+  test('it applies an input modifier before applying vulnerability', async function (assert) {
+    const details = new DamageDetails(
+      DamageType.RADIANT.name,
+      '2d6 + 1',
+      {
+        total: 9,
+        rolls: [
+          {
+            name: '2d6',
+            rolls: [3, 5],
+          },
+        ],
+      },
+      false,
+      true,
+    );
+    assert.equal(
+      details.getInflictedDamage(0.5),
+      8,
+      'roll should inflict floor(9 * 0.5) * 2 = 8 damage, not floor(9 * 2) * 0.5 = 9 damage',
+    );
+  });
+});

--- a/tests/unit/utils/repeated-save-test.ts
+++ b/tests/unit/utils/repeated-save-test.ts
@@ -3,7 +3,9 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 
 import AdvantageState from 'multiattack-5e/components/advantage-state-enum';
+import DamageType from 'multiattack-5e/components/damage-type-enum';
 import RandomnessService from 'multiattack-5e/services/randomness';
+import Damage from 'multiattack-5e/utils/damage';
 import RepeatedSave from 'multiattack-5e/utils/repeated-save';
 
 module('Unit | Utils | repeated-save', function (hooks) {
@@ -16,7 +18,6 @@ module('Unit | Utils | repeated-save', function (hooks) {
       '3',
       AdvantageState.ADVANTAGE,
       new RandomnessService(),
-      false,
     );
 
     const fakeD20 = sinon.stub();
@@ -55,7 +56,6 @@ module('Unit | Utils | repeated-save', function (hooks) {
       '3',
       AdvantageState.DISADVANTAGE,
       new RandomnessService(),
-      false,
     );
 
     const fakeD20 = sinon.stub();
@@ -94,7 +94,6 @@ module('Unit | Utils | repeated-save', function (hooks) {
       '3',
       AdvantageState.STRAIGHT,
       new RandomnessService(),
-      false,
     );
 
     const fakeD20 = sinon.stub();
@@ -149,5 +148,353 @@ module('Unit | Utils | repeated-save', function (hooks) {
         },
       ],
     });
+  });
+
+  test('it handles damage correctly when save-for-half is true', async function (assert) {
+    const repeatedSave = new RepeatedSave(
+      2,
+      10,
+      '3',
+      AdvantageState.STRAIGHT,
+      new RandomnessService(),
+      false,
+      true,
+      [new Damage('2d8', DamageType.RADIANT.name, new RandomnessService())],
+    );
+
+    const fakeD20 = sinon.stub();
+    fakeD20.onCall(0).returns(3);
+    fakeD20.onCall(1).returns(15);
+    repeatedSave.die.getD20Roll = fakeD20; //stubReturning(3, 15);
+
+    const fakeD8 = sinon.stub();
+    fakeD8.onCall(0).returns(4);
+    fakeD8.onCall(1).returns(5);
+    repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = fakeD8;
+
+    const result = repeatedSave.simulateRepeatedSaves();
+
+    // Other tests check the overall structure of the result; focus on the
+    // damage
+    assert.strictEqual(
+      result.totalDmg,
+      13,
+      'both saves should have inflicted damage (with the same damage roll for both saves) for a total of 9 + (9/2) = 13 damage',
+    );
+
+    // Inspect the failed save
+    const failedSaveDetails = result.detailsList[0];
+    assert.false(
+      failedSaveDetails?.pass,
+      'the failed save should be listed first',
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damage,
+      9,
+      'failed save should inflict 9 damage',
+    );
+
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails.length,
+      1,
+      'failed save should have one damage detail',
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails[0]!.inflicted,
+      9,
+      "failed save's damage should have inflicted 9 damage",
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails[0]!.details.roll.total,
+      9,
+      "failed save's damage should have rolled 9 total damage",
+    );
+    assert.deepEqual(
+      failedSaveDetails?.damageDetails[0]!.details.roll.rolls,
+      [
+        {
+          name: '2d8',
+          rolls: [4, 5],
+        },
+      ],
+      "failed save's damage should reflect mocked die rolls",
+    );
+
+    // Inspect the passed save
+    const passedSaveDetails = result.detailsList[1];
+    assert.true(
+      passedSaveDetails?.pass,
+      'the passed save should be listed second',
+    );
+    assert.strictEqual(
+      passedSaveDetails?.damage,
+      4,
+      'passed save should inflict half damage',
+    );
+
+    assert.strictEqual(
+      passedSaveDetails?.damageDetails.length,
+      1,
+      'passed save should have one damage detail',
+    );
+    assert.strictEqual(
+      passedSaveDetails?.damageDetails[0]!.inflicted,
+      4,
+      "passed save's damage should have inflicted 4 damage",
+    );
+    assert.strictEqual(
+      passedSaveDetails?.damageDetails[0]!.details.roll.total,
+      9,
+      "passed save's damage should have rolled 9 total damage",
+    );
+    assert.deepEqual(
+      passedSaveDetails?.damageDetails[0]!.details.roll.rolls,
+      [
+        {
+          name: '2d8',
+          rolls: [4, 5],
+        },
+      ],
+      "passed save's damage should reflect mocked die rolls",
+    );
+  });
+
+  test('it handles damage correctly when save-for-half is false', async function (assert) {
+    const repeatedSave = new RepeatedSave(
+      2,
+      10,
+      '3',
+      AdvantageState.STRAIGHT,
+      new RandomnessService(),
+      false,
+      false,
+      [new Damage('2d8', DamageType.RADIANT.name, new RandomnessService())],
+    );
+
+    const fakeD20 = sinon.stub();
+    fakeD20.onCall(0).returns(3);
+    fakeD20.onCall(1).returns(15);
+    repeatedSave.die.getD20Roll = fakeD20; //stubReturning(3, 15);
+
+    const fakeD8 = sinon.stub();
+    fakeD8.onCall(0).returns(4);
+    fakeD8.onCall(1).returns(5);
+    repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = fakeD8;
+
+    const result = repeatedSave.simulateRepeatedSaves();
+
+    // Other tests check the overall structure of the result; focus on the
+    // damage
+    assert.strictEqual(
+      result.totalDmg,
+      9,
+      'only the failed save should have inflicted damage for a total of 9 damage',
+    );
+
+    // Inspect the failed save
+    const failedSaveDetails = result.detailsList[0];
+    assert.false(
+      failedSaveDetails?.pass,
+      'the failed save should be listed first',
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damage,
+      9,
+      'failed save should inflict 9 damage',
+    );
+
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails.length,
+      1,
+      'failed save should have one damage detail',
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails[0]!.inflicted,
+      9,
+      "failed save's damage should have inflicted 9 total damage",
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails[0]!.details.roll.total,
+      9,
+      "failed save's damage should have rolled 9 total damage",
+    );
+    assert.deepEqual(
+      failedSaveDetails?.damageDetails[0]!.details.roll.rolls,
+      [
+        {
+          name: '2d8',
+          rolls: [4, 5],
+        },
+      ],
+      "failed save's damage should reflect mocked die rolls",
+    );
+
+    // Inspect the passed save
+    const passedSaveDetails = result.detailsList[1];
+    assert.true(
+      passedSaveDetails?.pass,
+      'the passed save should be listed second',
+    );
+    assert.strictEqual(
+      passedSaveDetails?.damage,
+      0,
+      'passed save should inflict no damage',
+    );
+    assert.deepEqual(
+      passedSaveDetails?.damageDetails,
+      [],
+      'passed save should have no damage details',
+    );
+  });
+
+  test('it handles resistance and vulnerability', async function (assert) {
+    const repeatedSave = new RepeatedSave(
+      2,
+      10,
+      '3',
+      AdvantageState.STRAIGHT,
+      new RandomnessService(),
+      false,
+      true,
+      [
+        new Damage(
+          '2d8',
+          DamageType.RADIANT.name,
+          new RandomnessService(),
+          true,
+        ),
+        new Damage(
+          '3d4',
+          DamageType.COLD.name,
+          new RandomnessService(),
+          false,
+          true,
+        ),
+      ],
+    );
+
+    const fakeD20 = sinon.stub();
+    fakeD20.onCall(0).returns(3);
+    fakeD20.onCall(1).returns(15);
+    repeatedSave.die.getD20Roll = fakeD20; //stubReturning(3, 15);
+
+    const fakeD8 = sinon.stub();
+    fakeD8.onCall(0).returns(4);
+    fakeD8.onCall(1).returns(5);
+    repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = fakeD8;
+
+    const fakeD4 = sinon.stub();
+    fakeD4.onCall(0).returns(4);
+    fakeD4.onCall(1).returns(2);
+    fakeD4.onCall(2).returns(1);
+    repeatedSave.damageTypes[1]!.damage.diceGroups[0]!.die.roll = fakeD4;
+
+    const result = repeatedSave.simulateRepeatedSaves();
+
+    // Other tests check the overall structure of the result; focus on the
+    // damage
+    assert.strictEqual(
+      result.totalDmg,
+      26,
+      'both saves should have inflicted damage (with the same damage roll for both saves) for a total of 18 + 8 = 26 damage',
+    );
+
+    // Inspect the failed save
+    const failedSaveDetails = result.detailsList[0];
+    assert.false(
+      failedSaveDetails?.pass,
+      'the failed save should be listed first',
+    );
+    assert.strictEqual(
+      failedSaveDetails?.damage,
+      18,
+      'failed save should inflict 9 / 2 radiant damage (resistance) and 7 * 2 cold damage (vulnerability)',
+    );
+
+    assert.strictEqual(
+      failedSaveDetails?.damageDetails.length,
+      2,
+      'failed save should have two damage details',
+    );
+
+    let radiantDetails = failedSaveDetails!.damageDetails[0]!;
+    assert.strictEqual(
+      radiantDetails.details.type,
+      DamageType.RADIANT.name,
+      "failed save's first damage type should be radiant",
+    );
+    assert.strictEqual(
+      radiantDetails.inflicted,
+      4,
+      "failed save's first damage type should have inflicted 4 total damage (resistance)",
+    );
+    assert.strictEqual(
+      radiantDetails.details.roll.total,
+      9,
+      "failed save's first damage type should have rolled 9 total damage",
+    );
+
+    let coldDetails = failedSaveDetails!.damageDetails[1]!;
+    assert.strictEqual(
+      coldDetails.details.type,
+      DamageType.COLD.name,
+      "failed save's second damage type should be cold",
+    );
+    assert.strictEqual(
+      coldDetails.inflicted,
+      14,
+      "failed save's second damage type should have inflicted 14 total damage (vulnerability)",
+    );
+    assert.strictEqual(
+      coldDetails.details.roll.total,
+      7,
+      "failed save's second damage type should have rolled 7 total damage",
+    );
+
+    // Inspect the passed save
+    const passedSaveDetails = result.detailsList[1];
+    assert.true(
+      passedSaveDetails?.pass,
+      'the passed save should be listed second',
+    );
+    assert.strictEqual(
+      passedSaveDetails?.damage,
+      8,
+      'passed save should inflict (9 / 2) / 2 radiant damage (passed save + resistance) and (7 / 2) * 2 of the cold damage rolled (passed save + vulnerability)',
+    );
+
+    radiantDetails = passedSaveDetails!.damageDetails[0]!;
+    assert.strictEqual(
+      radiantDetails.details.type,
+      DamageType.RADIANT.name,
+      "passed save's first damage type should be radiant",
+    );
+    assert.strictEqual(
+      radiantDetails.inflicted,
+      2,
+      "passed save's first damage type should have inflicted 2 total damage (passed + resistance)",
+    );
+    assert.strictEqual(
+      radiantDetails.details.roll.total,
+      9,
+      "passed save's first damage type should have rolled 9 total damage",
+    );
+
+    coldDetails = passedSaveDetails!.damageDetails[1]!;
+    assert.strictEqual(
+      coldDetails.details.type,
+      DamageType.COLD.name,
+      "passed save's second damage type should be cold",
+    );
+    assert.strictEqual(
+      coldDetails.inflicted,
+      6,
+      "passed save's second damage type should have inflicted 6 total damage (passed + vulnerability)",
+    );
+    assert.strictEqual(
+      coldDetails.details.roll.total,
+      7,
+      "passed save's second damage type should have rolled 7 total damage",
+    );
   });
 });


### PR DESCRIPTION
This implements support for linking damage to saving throws, including half-damage on successful saves. Currently, damage is rolled only once and applied to all saves in the set.

To support inflicting half damage on successful saves, and only afterwards applying resistance and vulnerability (as is required by the definition of resistance and vulnerability), this refactors damage handling to separate rolling damage and calculating the damage that results from the die rolls. The total of a damage's dice and modifiers, and the amount of damage inflicted, are tracked separately.