### PR TITLE
Use updated node version in Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request: {}
 
 concurrency:
@@ -18,11 +17,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 21.x
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -35,11 +34,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 21.x
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/tests/acceptance/main-page-test.ts
+++ b/tests/acceptance/main-page-test.ts
@@ -157,7 +157,7 @@ module('Acceptance | main page', function (hooks) {
 
   function delay() {
     return new Promise((resolve) => {
-      setTimeout(resolve, 100);
+      setTimeout(resolve, 500);
     });
   }
 });


### PR DESCRIPTION
This updates the version of github actions being used to a
version which no longer uses the deprecated node 16, and
installs an updated version of node in the actions.

It also increases the delay between switching tabs and
analyzing the visible page in the test for the main page,
which is flaky when the delay is only 100 milliseconds because
the tab switch may not complete before the visibility of
elements is checked.