### PR TITLE
Support re-rolling the damage for each save in repeated saves

### DIFF
--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -80,13 +80,13 @@
           Save for half damage
         </label>
       </div>
-      {{!-- <div class="form-check">
+      <div class="form-check">
         <Input data-test-input-roll-dmg-every-save class="form-check-input" @type="checkbox" id="rollDamageEverySave"
           name="rollDamageEverySave" @checked={{this.rollDamageEverySave}} />
         <label class="form-check-label" for="rollDamageEverySave">
-          Roll new damage with every save
+          Roll new damage for every save
         </label>
-      </div> --}}
+      </div>
 
       <hr />
 

--- a/app/utils/repeated-save.ts
+++ b/app/utils/repeated-save.ts
@@ -137,6 +137,17 @@ export default class RepeatedSave {
 
     // Roll all saves
     for (let i = 0; i < this.numberOfSaves; i++) {
+      // Get the damage that might be inflicted by this save
+      let damageDetails = [];
+      if (this.rollDamageEverySave) {
+        for (const damage of this.damageTypes) {
+          damageDetails.push(damage.roll(false));
+        }
+      } else {
+        damageDetails = cachedDamageDetails;
+      }
+
+      // Roll the d20 for the saving throw
       const saveRoll = this.die.roll();
 
       const saveDetail: SaveDetails = {
@@ -149,6 +160,7 @@ export default class RepeatedSave {
         damageDetails: [],
       };
 
+      // Handle pass or failure of the save
       if (saveRoll.total >= this.saveDC) {
         saveDetail.pass = true;
         totalNumberOfPasses += 1;
@@ -156,7 +168,7 @@ export default class RepeatedSave {
         // Some saving throws inflict half damage when a save is passed
         if (this.saveForHalf) {
           const totalInflictedBySave = this.getTotalInflictedDamage(
-            cachedDamageDetails,
+            damageDetails,
             saveDetail.damageDetails,
             0.5,
           );
@@ -167,7 +179,7 @@ export default class RepeatedSave {
       } else {
         // When a save is failed, inflict full damage (if applicable)
         const totalInflictedBySave = this.getTotalInflictedDamage(
-          cachedDamageDetails,
+          damageDetails,
           saveDetail.damageDetails,
         );
 


### PR DESCRIPTION
If multiple identical attacks require the same entity (or identical entities) to roll saves, each of the saves might inflict new damage. This updates the form to support rolling new damage on every save.

Some cases, such as a single fireball striking a group of identical targets, will instead require the same damage to be inflicted by all saves (possibly halved on pass); this is also supported.