### PR TITLE
Indicate halved damage rolls in save detail display

### DIFF
--- a/app/components/detail-damage-display.hbs
+++ b/app/components/detail-damage-display.hbs
@@ -21,10 +21,13 @@
         {{/unless}}
         {{damage.details.type}}
         damage
-        {{#if (@shouldBoldDice @setDetails)}}
-          (<b>{{damage.details.dice}}</b>){{/if}}
-        {{#unless (@shouldBoldDice @setDetails)}}
-          ({{damage.details.dice}}){{/unless}}
+        {{#if (@shouldBoldDice @contextDetails)}}
+          (<b>{{damage.details.dice}}</b>)
+        {{/if}}
+        {{#unless (@shouldBoldDice @contextDetails)}}
+          ({{damage.details.dice}})
+        {{/unless}}
+        {{@getDamageModifications @contextDetails}}
         {{#if damage.details.resisted}} (resisted){{/if}}
         {{#if damage.details.vulnerable}} (vulnerable){{/if}}
       </span>

--- a/app/components/detail-display.hbs
+++ b/app/components/detail-display.hbs
@@ -89,7 +89,8 @@
                   @index2={{index2}}
                   @getRollDetailString={{this.getRollDetailString}}
                   @shouldBoldDice={{@shouldBoldDice}}
-                  @setDetails={{details}}
+                  @contextDetails={{details}}
+                  @getDamageModifications={{@getDamageModifications}}
                   @getStringWithSpaces={{this.getStringWithSpaces}}
                 />
               </li>
@@ -134,7 +135,8 @@
                   @index2={{index2}}
                   @getRollDetailString={{this.getRollDetailString}}
                   @shouldBoldDice={{@shouldBoldDice}}
-                  @setDetails={{details}}
+                  @contextDetails={{details}}
+                  @getDamageModifications={{@getDamageModifications}}
                   @getStringWithSpaces={{this.getStringWithSpaces}}
                 />
               </li>

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -98,6 +98,7 @@
       @isSuccess={{this.isHit}}
       @getD20RollString={{this.getD20RollString}}
       @shouldBoldDice={{this.shouldBoldDice}}
+      @getDamageModifications={{this.getDamageModifications}}
     />
   </div>
 </div>

--- a/app/components/repeated-attack-form.ts
+++ b/app/components/repeated-attack-form.ts
@@ -149,6 +149,11 @@ export default class RepeatedAttackFormComponent extends Component {
     return attack.hit;
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getDamageModifications = (ignored: AttackDetails) => {
+    return '';
+  };
+
   simulateRepeatedAttacks = () => {
     if (!this.randomness) {
       throw new Error(

--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -80,10 +80,16 @@
           Save for half damage
         </label>
       </div>
-      <div class="form-check">
-        <Input data-test-input-roll-dmg-every-save class="form-check-input" @type="checkbox" id="rollDamageEverySave"
-          name="rollDamageEverySave" @checked={{this.rollDamageEverySave}} />
-        <label class="form-check-label" for="rollDamageEverySave">
+      <div class='form-check'>
+        <Input
+          data-test-input-roll-dmg-every-save
+          class='form-check-input'
+          @type='checkbox'
+          id='rollDamageEverySave'
+          name='rollDamageEverySave'
+          @checked={{this.rollDamageEverySave}}
+        />
+        <label class='form-check-label' for='rollDamageEverySave'>
           Roll new damage for every save
         </label>
       </div>
@@ -121,6 +127,7 @@
       @isSuccess={{this.isPass}}
       @getD20RollString={{this.getD20RollString}}
       @shouldBoldDice={{this.shouldBoldDice}}
+      @getDamageModifications={{this.getDamageModifications}}
     />
   </div>
 </div>

--- a/app/components/repeated-save-form.ts
+++ b/app/components/repeated-save-form.ts
@@ -149,6 +149,17 @@ export default class RepeatedSaveFormComponent extends Component {
     return save.pass;
   };
 
+  getDamageModifications = (save: SaveDetails) => {
+    // If this method is called at all, it is because damage was inflicted by
+    // this save. Only save-for-half and save-for-no-damage are currently
+    // supported, so if damage is inflicted on a pass it must be half damage.
+    if (save.pass) {
+      return ' (halved)';
+    } else {
+      return '';
+    }
+  };
+
   simulateRepeatedSaves = () => {
     if (!this.randomness) {
       throw new Error(

--- a/tests/integration/components/detail-display-test.ts
+++ b/tests/integration/components/detail-display-test.ts
@@ -199,7 +199,7 @@ module('Integration | Component | detail-display', function (hooks) {
       @getThresholdString={{this.getThresholdString}} @getD20Modifier={{this.getD20Modifier}}
       @getRollString={{this.getRollString}} @isSuccess={{this.isSuccess}}
       @getD20RollString={{this.getD20RollString}}
-      @shouldBoldDice={{this.shouldBoldDice}} />`,
+      @shouldBoldDice={{this.shouldBoldDice}} @getDamageModifications={{this.getDamageModifications}} />`,
     );
 
     assert
@@ -239,7 +239,7 @@ module('Integration | Component | detail-display', function (hooks) {
     assert
       .dom('[data-test-roll-detail="0-0"]')
       .hasAttribute('title', '1d20: 20 | -1d6: 2')
-      .hasText('21 from roll');
+      .hasText('21 from roll (major success)');
 
     // success 2
     assert.equal(
@@ -277,7 +277,7 @@ module('Integration | Component | detail-display', function (hooks) {
     assert
       .dom('[data-test-damage-roll-detail="0-0-0"]')
       .hasAttribute('title', '4d6: 4, 5, 2, 2 | 2d4: 3, 2')
-      .hasText('11 piercing damage (4d6 + 2d4 + 5) (resisted)');
+      .hasText('11 piercing damage (4d6 + 2d4 + 5) (major success) (resisted)');
     assert
       .dom('[data-test-damage-roll-collapse-link="0-0-0"]')
       .hasAria('expanded', 'false')
@@ -289,7 +289,7 @@ module('Integration | Component | detail-display', function (hooks) {
     assert
       .dom('[data-test-damage-roll-detail="0-0-1"]')
       .hasAttribute('title', '4d8: 2, 7, 1, 3')
-      .hasText('26 radiant damage (4d8) (vulnerable)');
+      .hasText('26 radiant damage (4d8) (major success) (vulnerable)');
     assert
       .dom('[data-test-damage-roll-collapse-link="0-0-1"]')
       .hasAria('expanded', 'false')
@@ -502,7 +502,7 @@ module('Integration | Component | detail-display', function (hooks) {
       @getThresholdString={{this.getThresholdString}} @getD20Modifier={{this.getD20Modifier}}
       @getRollString={{this.getRollString}} @isSuccess={{this.isSuccess}}
       @getD20RollString={{this.getD20RollString}}
-      @shouldBoldDice={{this.shouldBoldDice}} />`,
+      @shouldBoldDice={{this.shouldBoldDice}} @getDamageModifications={{this.getDamageModifications}} />`,
     );
 
     // First set of repeated events
@@ -647,7 +647,7 @@ module('Integration | Component | detail-display', function (hooks) {
       @getThresholdString={{this.getThresholdString}} @getD20Modifier={{this.getD20Modifier}}
       @getRollString={{this.getRollString}} @isSuccess={{this.isSuccess}}
       @getD20RollString={{this.getD20RollString}}
-      @shouldBoldDice={{this.shouldBoldDice}} />`,
+      @shouldBoldDice={{this.shouldBoldDice}} @getDamageModifications={{this.getDamageModifications}} />`,
     );
 
     // The damage should not have been formatted as a link since there were no
@@ -708,7 +708,7 @@ module('Integration | Component | detail-display', function (hooks) {
       @getThresholdString={{this.getThresholdString}} @getD20Modifier={{this.getD20Modifier}}
       @getRollString={{this.getRollString}} @isSuccess={{this.isSuccess}}
       @getD20RollString={{this.getD20RollString}}
-      @shouldBoldDice={{this.shouldBoldDice}} />`,
+      @shouldBoldDice={{this.shouldBoldDice}} @getDamageModifications={{this.getDamageModifications}} />`,
     );
 
     assert
@@ -789,7 +789,7 @@ module('Integration | Component | detail-display', function (hooks) {
       @getThresholdString={{this.getThresholdString}} @getD20Modifier={{this.getD20Modifier}}
       @getRollString={{this.getRollString}} @isSuccess={{this.isSuccess}}
       @getD20RollString={{this.getD20RollString}}
-      @shouldBoldDice={{this.shouldBoldDice}} />`,
+      @shouldBoldDice={{this.shouldBoldDice}} @getDamageModifications={{this.getDamageModifications}} />`,
     );
 
     assert
@@ -863,13 +863,22 @@ module('Integration | Component | detail-display', function (hooks) {
       return eventData.success;
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    context.set('getD20RollString', (ignored: TestEventDetails) => {
-      return `from roll`;
+    context.set('getD20RollString', (eventData: TestEventDetails) => {
+      if (eventData.majorSuccess) {
+        return 'from roll (major success)';
+      }
+      return 'from roll';
     });
 
     context.set('shouldBoldDice', (eventData: TestEventDetails) => {
       return eventData.majorSuccess;
+    });
+
+    context.set('getDamageModifications', (eventData: TestEventDetails) => {
+      if (eventData.majorSuccess) {
+        return ' (major success)';
+      }
+      return '';
     });
   }
 });


### PR DESCRIPTION
This updates the save damage display to include '(halved)' when damage has been halved by a pass in a save-for-half-damage situation. Resistance and vulnerability are still displayed as well, and this adds tests for both attacks and saves to verify that the display is as expected (using fixed dice).

This also updates the fixed-dice save tests to switch to the save tab before running the main tests. This makes debugging the tests easier, as the save tab is displayed in the testing pane while the tests are running.