### PR TITLE
Update text to reflect saves and fix test labels

### DIFF
--- a/app/components/main-page.hbs
+++ b/app/components/main-page.hbs
@@ -2,18 +2,24 @@
   <div class='row align-items-center'>
     <div class='col col-lg-9 pt-5 pb-2'>
       <div class='container-readable-width'>
-        <h1>Repeated Attack Simulator</h1>
+        <h1>Repeated Attack and Save Simulator</h1>
         <p>
-          Did a druid just summon a pack of wolves? Has a necromancer gathered a
-          zombie horde? Is a marilith focusing on a single opponent? This tool
-          simulates repeated identical attacks on a single target and displays
-          the total damage alongside a breakdown of the attacks.
+          Did a druid just summon a pack of wolves? Is a marilith focusing on a
+          single opponent? The tool under the "Attacks" tab simulates repeated
+          identical attacks on a single target and displays the total damage
+          alongside a breakdown of the attacks.
         </p>
         <p>
-          This uses a 20-sided die for attack rolls, as in D&D 5e and similar
-          systems. If an attack is a critical hit (rolls a 20), the damage dice
-          are rolled twice. Rolling a 1 on the d20 always misses, and a 20
-          always hits.
+          Is a rival mage fireballing a necromancer's zombie horde? Are a group
+          of pixies all trying to bewilder an intruder's mind? Switch to the
+          "Saves" tab to simulate repeated identical saving throws against
+          optional damage.
+        </p>
+        <p>
+          This uses a 20-sided die for attack rolls and saving throws, as in D&D
+          5e and similar systems. If an attack is a critical hit (rolls a 20),
+          the damage dice are rolled twice. For attacks, rolling a 1 on the d20
+          always misses, and a 20 always hits.
         </p>
       </div>
     </div>

--- a/app/components/repeated-attack-form.hbs
+++ b/app/components/repeated-attack-form.hbs
@@ -75,7 +75,7 @@
 
       <div class='row align-items-center mx-auto mb-5'>
         <button
-          data-test-button-getDamage
+          data-test-button-rollAttacks
           class='btn btn-primary btn-lg w-70 d-block'
           type='submit'
           id='attackBtn'

--- a/tests/acceptance/main-page-test.ts
+++ b/tests/acceptance/main-page-test.ts
@@ -77,8 +77,8 @@ module('Acceptance | main page', function (hooks) {
       .isVisible('attack form label should be displayed');
 
     // Trigger two attacks (with the default configuration)
-    await click('[data-test-button-getDamage]');
-    await click('[data-test-button-getDamage]');
+    await click('[data-test-button-rollAttacks]');
+    await click('[data-test-button-rollAttacks]');
 
     // Check and save the first damage header
     assert

--- a/tests/acceptance/main-page-test.ts
+++ b/tests/acceptance/main-page-test.ts
@@ -19,7 +19,10 @@ module('Acceptance | main page', function (hooks) {
     // Check for the expected header
     assert
       .dom('h1')
-      .hasText('Repeated Attack Simulator', 'page title should be displayed');
+      .hasText(
+        'Repeated Attack and Save Simulator',
+        'page title should be displayed',
+      );
   });
 
   test('switching between tabs', async function (assert) {

--- a/tests/acceptance/repeated-attack-form-test.ts
+++ b/tests/acceptance/repeated-attack-form-test.ts
@@ -49,7 +49,7 @@ module('Acceptance | repeated attack form', function (hooks) {
       );
 
     // Calculate the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     assert
       .dom('#nav-attacks [data-test-data-list="0"]')
@@ -87,7 +87,7 @@ module('Acceptance | repeated attack form', function (hooks) {
     await click('#nav-attacks [data-test-value="disadvantage"]');
 
     // Calculate the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // Change some attack details
     await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '4');
@@ -95,7 +95,7 @@ module('Acceptance | repeated attack form', function (hooks) {
     await fillIn('#nav-attacks [data-test-input-toHit]', '3');
 
     // Attack again
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // The second attack should be displayed first
     assert
@@ -266,7 +266,7 @@ module('Acceptance | repeated attack form', function (hooks) {
     await visit('/');
 
     // Attack (using the default setup)
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // There should be one set of attack details displayed
     assert
@@ -277,8 +277,8 @@ module('Acceptance | repeated attack form', function (hooks) {
       .doesNotExist('only one attack set should be displayed');
 
     // Attack twice more
-    await click('#nav-attacks [data-test-button-getDamage]');
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // There should be three sets of attack details displayed
     assert

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -33,7 +33,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await click('#nav-attacks [data-test-input-resistant="0"]');
 
     // Calculate the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     assert
       .dom('#nav-attacks [data-test-data-list="0"]')
@@ -158,7 +158,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     );
 
     // Calculate the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     assert
       .dom('#nav-attacks [data-test-data-list="0"]')
@@ -210,7 +210,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await click('#nav-attacks [data-test-value="advantage"]');
 
     // Calculate the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     assert
       .dom('#nav-attacks [data-test-data-list="0"]')
@@ -275,7 +275,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     );
 
     // Trigger the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // Change the attack details so that the next set of attacks will miss
     await fillIn('#nav-attacks [data-test-input-numberOfAttacks]', '1');
@@ -283,7 +283,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await click('#nav-attacks [data-test-value="straight"]');
 
     // Trigger the attack
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // Inspect the second attack's details, which will be displayed first
     assert
@@ -515,19 +515,19 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     await click('#nav-attacks [data-test-input-resistant="0"]');
 
     // Roll the attacks
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // Add vulnerability
     await click('#nav-attacks [data-test-input-vulnerable="0"]');
 
     // Roll a second set of attacks
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // Remove damage resistance
     await click('#nav-attacks [data-test-input-resistant="0"]');
 
     // Roll a third set of attacks
-    await click('#nav-attacks [data-test-button-getDamage]');
+    await click('#nav-attacks [data-test-button-rollAttacks]');
 
     // Most recent attack: vulnerability only
     assert


### PR DESCRIPTION
This updates the main-page text now that saves are supported, giving examples of when the tool might be used. It also changes the test-only label for the button which triggers attacks, for clarity and symmetry with the button which triggers saves.