### PR TITLE
Display d20 rolls with advantage and disadvantage for attacks/saves

### DIFF
--- a/app/utils/d20-with-modifiers.ts
+++ b/app/utils/d20-with-modifiers.ts
@@ -44,37 +44,50 @@ export default class D20WithModifiers {
     };
 
     // Roll the d20, with advantage or disadvantage as indicated
-    const d20Roll = this.getD20Roll();
-    rollDetails.total = d20Roll;
-    rollDetails.baseD20Roll = d20Roll;
-    rollDetails.rolls.push({
-      name: '1d20',
-      rolls: [d20Roll],
-    });
-
-    // Roll modifiers
-    const modifierRollDetails = this.modifier.roll(false);
-    rollDetails.total += modifierRollDetails.total;
-    rollDetails.rolls.push(...modifierRollDetails.rolls);
-    return rollDetails;
-  }
-
-  getD20Roll(): number {
     const roll1 = this.die.roll();
     const roll2 = this.die.roll();
 
     switch (this.advantageState) {
       case AdvantageState.STRAIGHT:
-        return roll1;
+        // Choose roll1 arbitrarily for a straight roll, and ignore roll2 since
+        // technically the d20 should only have been rolled once
+        rollDetails.total = roll1;
+        rollDetails.baseD20Roll = roll1;
+        rollDetails.rolls.push({
+          name: '1d20',
+          rolls: [roll1],
+        });
+        break;
       case AdvantageState.ADVANTAGE:
-        return Math.max(roll1, roll2);
+        // Record both rolls and choose the higher as the output roll
+        rollDetails.total = Math.max(roll1, roll2);
+        rollDetails.baseD20Roll = Math.max(roll1, roll2);
+        rollDetails.rolls.push({
+          name: '1d20',
+          rolls: [roll1, roll2],
+        });
+        break;
       case AdvantageState.DISADVANTAGE:
-        return Math.min(roll1, roll2);
+        // Record both rolls and choose the lower as the output roll
+        rollDetails.total = Math.min(roll1, roll2);
+        rollDetails.baseD20Roll = Math.min(roll1, roll2);
+        rollDetails.rolls.push({
+          name: '1d20',
+          rolls: [roll1, roll2],
+        });
+        break;
       default:
         // This should not be reachable.
         throw new Error(
           `Unexpected error when rolling d20; app logic does not handle advantage state ${this.advantageState}. Please file an issue in Github.`,
         );
     }
+
+    // Roll modifiers (only once, since advantage/disadvantage only affects the
+    // d20 roll)
+    const modifierRollDetails = this.modifier.roll(false);
+    rollDetails.total += modifierRollDetails.total;
+    rollDetails.rolls.push(...modifierRollDetails.rolls);
+    return rollDetails;
   }
 }

--- a/tests/acceptance/repeated-attack-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-attack-form-with-fakes-test.ts
@@ -228,7 +228,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
     // The attack roll should not be marked as a crit or as a natural one
     assert
       .dom(`#nav-attacks [data-test-roll-detail="0-0"]`)
-      .hasAttribute('title', '1d20: 17')
+      .hasAttribute('title', '1d20: 17, 17')
       .hasText('20 to hit');
 
     // Examine the damage section
@@ -367,7 +367,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
       // Examine the attack roll section
       assert
         .dom(`#nav-attacks [data-test-roll-detail="1-${i}"]`)
-        .hasAttribute('title', '1d20: 15')
+        .hasAttribute('title', '1d20: 15, 15')
         .hasText('17 to hit');
 
       // Test the collapsible attack-roll details
@@ -377,7 +377,7 @@ module('Acceptance | repeated attack form with fake dice', function (hooks) {
         .hasText('17');
       assert
         .dom(`#nav-attacks [data-test-roll-collapse-pane="1-${i}"]`)
-        .hasText('1d20: 15')
+        .hasText('1d20: 15, 15')
         .doesNotHaveClass(
           'show',
           'attack roll detail pane should start collapsed',

--- a/tests/unit/utils/attack-test.ts
+++ b/tests/unit/utils/attack-test.ts
@@ -13,6 +13,42 @@ import { DamageDetails } from 'multiattack-5e/utils/damage-details';
 module('Unit | Utils | attack', function (hooks) {
   setupTest(hooks);
 
+  test('it displays advantage correctly', async function (assert) {
+    const attack = new Attack(
+      '4',
+      AdvantageState.ADVANTAGE,
+      [],
+      new RandomnessService(),
+    );
+    attack.attackDie.die.roll = stubReturning(3, 8);
+
+    // This attack rolls 8 + 4 = 12
+    const attackData = attack.makeAttack(10);
+    assert.deepEqual(
+      attackData.roll,
+      { total: 12, rolls: [{ name: '1d20', rolls: [3, 8] }] },
+      'attack should have rolled a 12',
+    );
+  });
+
+  test('it displays disadvantage correctly', async function (assert) {
+    const attack = new Attack(
+      '4',
+      AdvantageState.DISADVANTAGE,
+      [],
+      new RandomnessService(),
+    );
+    attack.attackDie.die.roll = stubReturning(3, 8);
+
+    // This attack rolls 3 + 4 = 7
+    const attackData = attack.makeAttack(10);
+    assert.deepEqual(
+      attackData.roll,
+      { total: 7, rolls: [{ name: '1d20', rolls: [3, 8] }] },
+      'attack should have rolled a 7',
+    );
+  });
+
   test('it handles an AC-based miss correctly', async function (assert) {
     const attack = new Attack(
       '4',
@@ -20,7 +56,7 @@ module('Unit | Utils | attack', function (hooks) {
       [],
       new RandomnessService(),
     );
-    attack.attackDie.getD20Roll = stubReturning(3);
+    attack.attackDie.die.roll = stubReturning(3, 8);
 
     // This attack rolls 3 + 4 = 7, so it should miss
     const attackData = attack.makeAttack(10);
@@ -46,7 +82,7 @@ module('Unit | Utils | attack', function (hooks) {
       [],
       new RandomnessService(),
     );
-    attack.attackDie.getD20Roll = stubReturning(1);
+    attack.attackDie.die.roll = stubReturning(1, 8);
 
     // This attack rolls a nat 1, so it should miss even though 1 + 20 > 10
     const attackData = attack.makeAttack(10);
@@ -81,7 +117,7 @@ module('Unit | Utils | attack', function (hooks) {
     );
 
     // Fake the results of the attack-roll dice
-    attack.attackDie.getD20Roll = stubReturning(13);
+    attack.attackDie.die.roll = stubReturning(13, 8);
     attack.attackDie.modifier.diceGroups[0]!.roll = stubReturning({
       total: 6,
       rolls: [6],
@@ -126,7 +162,7 @@ module('Unit | Utils | attack', function (hooks) {
     );
 
     // Fake the results of the d20 attack roll
-    attack.attackDie.getD20Roll = stubReturning(13);
+    attack.attackDie.die.roll = stubReturning(13, 8);
 
     // Fake the results of the damage dice
     const fakePiercingDamageDetails = new DamageDetails(
@@ -215,7 +251,7 @@ module('Unit | Utils | attack', function (hooks) {
     );
 
     // Fake the results of the d20 attack roll
-    attack.attackDie.getD20Roll = stubReturning(20);
+    attack.attackDie.die.roll = stubReturning(20, 8);
 
     // Fake the results of the damage dice
     const fakePiercingDamageDetails = new DamageDetails(

--- a/tests/unit/utils/d20-with-modifiers-test.ts
+++ b/tests/unit/utils/d20-with-modifiers-test.ts
@@ -12,25 +12,47 @@ module('Unit | Utils | d20-with-mods', function (hooks) {
   test('it rolls with advantage', async function (assert) {
     const d20 = new D20WithModifiers(
       AdvantageState.ADVANTAGE,
-      '4',
+      '0',
       new RandomnessService(),
     );
     d20.die.roll = stubReturning(3, 7);
 
-    assert.strictEqual(d20.getD20Roll(), 7, 'die should roll with advantage');
+    assert.deepEqual(
+      d20.roll(),
+      {
+        total: 7,
+        baseD20Roll: 7,
+        rolls: [
+          {
+            name: '1d20',
+            rolls: [3, 7],
+          },
+        ],
+      },
+      'die should roll with advantage',
+    );
   });
 
   test('it rolls with disadvantage', async function (assert) {
     const d20 = new D20WithModifiers(
       AdvantageState.DISADVANTAGE,
-      '1',
+      '0',
       new RandomnessService(),
     );
     d20.die.roll = stubReturning(3, 7);
 
-    assert.strictEqual(
-      d20.getD20Roll(),
-      3,
+    assert.deepEqual(
+      d20.roll(),
+      {
+        total: 3,
+        baseD20Roll: 3,
+        rolls: [
+          {
+            name: '1d20',
+            rolls: [3, 7],
+          },
+        ],
+      },
       'die should roll with disadvantage',
     );
   });
@@ -38,20 +60,38 @@ module('Unit | Utils | d20-with-mods', function (hooks) {
   test('it rolls a straight roll', async function (assert) {
     const d20 = new D20WithModifiers(
       AdvantageState.STRAIGHT,
-      '1d6',
+      '0',
       new RandomnessService(),
     );
     d20.die.roll = stubReturning(3, 7, 6, 1);
 
-    assert.strictEqual(
-      d20.getD20Roll(),
-      3,
-      'die should use the first roll when making the first straight roll',
+    assert.deepEqual(
+      d20.roll(),
+      {
+        total: 3,
+        baseD20Roll: 3,
+        rolls: [
+          {
+            name: '1d20',
+            rolls: [3],
+          },
+        ],
+      },
+      'die should use the first roll when making the first straight roll (ignoring the second roll entirely)',
     );
 
-    assert.strictEqual(
-      d20.getD20Roll(),
-      6,
+    assert.deepEqual(
+      d20.roll(),
+      {
+        total: 6,
+        baseD20Roll: 6,
+        rolls: [
+          {
+            name: '1d20',
+            rolls: [6],
+          },
+        ],
+      },
       'die should use the first roll again when making a second straight roll',
     );
   });
@@ -96,7 +136,7 @@ module('Unit | Utils | d20-with-mods', function (hooks) {
         rolls: [
           {
             name: '1d20',
-            rolls: [3],
+            rolls: [7, 3],
           },
         ],
       },

--- a/tests/unit/utils/repeated-save-test.ts
+++ b/tests/unit/utils/repeated-save-test.ts
@@ -36,7 +36,7 @@ module('Unit | Utils | repeated-save', function (hooks) {
         {
           roll: {
             total: 10, // meeting the DC passes the save
-            rolls: [{ name: '1d20', rolls: [7] }],
+            rolls: [{ name: '1d20', rolls: [3, 7] }],
           },
           pass: true,
           damage: 0,
@@ -71,7 +71,7 @@ module('Unit | Utils | repeated-save', function (hooks) {
         {
           roll: {
             total: 6,
-            rolls: [{ name: '1d20', rolls: [3] }],
+            rolls: [{ name: '1d20', rolls: [3, 15] }],
           },
           pass: false,
           damage: 0,
@@ -147,7 +147,8 @@ module('Unit | Utils | repeated-save', function (hooks) {
       [new Damage('2d8', DamageType.RADIANT.name, new RandomnessService())],
     );
 
-    repeatedSave.die.getD20Roll = stubReturning(3, 15);
+    // the 2's are all ignored, since this is configured to use a straight roll
+    repeatedSave.die.die.roll = stubReturning(3, 2, 15, 2);
     repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = stubReturning(
       4,
       5,
@@ -252,7 +253,8 @@ module('Unit | Utils | repeated-save', function (hooks) {
       [new Damage('2d8', DamageType.RADIANT.name, new RandomnessService())],
     );
 
-    repeatedSave.die.getD20Roll = stubReturning(3, 15);
+    // the 2's are all ignored, since this is configured to use a straight roll
+    repeatedSave.die.die.roll = stubReturning(3, 2, 15, 2);
     repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = stubReturning(
       4,
       5,
@@ -350,7 +352,8 @@ module('Unit | Utils | repeated-save', function (hooks) {
       ],
     );
 
-    repeatedSave.die.getD20Roll = stubReturning(3, 15);
+    // the 2's are all ignored, since this is configured to use a straight roll
+    repeatedSave.die.die.roll = stubReturning(3, 2, 15, 2);
     repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = stubReturning(
       4,
       5,
@@ -483,7 +486,8 @@ module('Unit | Utils | repeated-save', function (hooks) {
     );
 
     // Both saves should fail
-    repeatedSave.die.getD20Roll = stubReturning(3, 4);
+    // the 2's are all ignored, since this is configured to use a straight roll
+    repeatedSave.die.die.roll = stubReturning(3, 2, 4, 2);
     repeatedSave.damageTypes[0]!.damage.diceGroups[0]!.die.roll = stubReturning(
       4,
       5,


### PR DESCRIPTION
Although all damage dice were displayed for attacks and saves, only one d20 roll was displayed on the UI even when the attack or save had been made with advantage or disadvantage. This was confusing, making it appear that the advantage or disadvantage might not be handled correctly. This commit updates the display to show a single d20 roll when a straight roll was made and two d20 rolls when a roll was made with advantage or disadvantage.