### PR TITLE
Reformat passed-save display and change default damage handling

### DIFF
--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -80,7 +80,6 @@
               type='radio'
               name='passedSaveRadio'
               id='noDamage'
-              checked
               {{on 'click' this.setNoDamageOnPassedSave}}
             />
             <label class='form-check-label' for='noDamage'>
@@ -95,6 +94,7 @@
               type='radio'
               name='passedSaveRadio'
               id='halfDamage'
+              checked
               {{on 'click' this.setHalfDamageOnPassedSave}}
             />
             <label class='form-check-label' for='halfDamage'>

--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -70,22 +70,40 @@
         </div>
       </div>
 
-      <hr />
+      <div class='row align-items-center py-2'>
+        <label class='col-6 col-form-label'>On Passed Save</label>
+        <div class='col-6'>
+          <div class='form-check'>
+            <input 
+              data-test-input-passedSave-noDamage
+              class='form-check-input'
+              type='radio'
+              name='passedSaveRadio'
+              id='noDamage'
+              checked
+              {{on 'click' this.setNoDamageOnPassedSave}}
+            />
+            <label class='form-check-label' for='noDamage'>
+              No Damage
+            </label>
+          </div>
 
-      <div class='form-check'>
-        <input
-          data-test-input-half-damage
-          class='form-check-input'
-          type='checkbox'
-          id='saveForHalfDamage'
-          name='saveForHalfDamage'
-          checked={{this.saveForHalfDamage}}
-          {{on 'change' this.setSaveForHalfDamage}}
-        />
-        <label class='form-check-label' for='saveForHalfDamage'>
-          Save for half damage
-        </label>
+          <div class='form-check'>
+            <input
+              data-test-input-passedSave-halfDamage
+              class='form-check-input'
+              type='radio'
+              name='passedSaveRadio'
+              id='halfDamage'
+              {{on 'click' this.setHalfDamageOnPassedSave}}
+            />
+            <label class='form-check-label' for='halfDamage'>
+              Half Damage
+            </label>
+          </div>
+        </div>
       </div>
+
       <div class='form-check'>
         <input
           data-test-input-roll-dmg-every-save

--- a/app/components/repeated-save-form.ts
+++ b/app/components/repeated-save-form.ts
@@ -27,7 +27,7 @@ export default class RepeatedSaveFormComponent extends Component {
   @tracked saveMod = '5 + 1d4';
 
   @tracked rollDamageEverySave = false;
-  @tracked saveForHalfDamage = false;
+  @tracked saveForHalfDamage = true;
   @tracked damageList: Damage[] = A([this.getDefaultDamage()]);
 
   @tracked advantageState = AdvantageState.STRAIGHT;

--- a/app/components/repeated-save-form.ts
+++ b/app/components/repeated-save-form.ts
@@ -41,7 +41,7 @@ export default class RepeatedSaveFormComponent extends Component {
   diceGroupsRegex = DiceStringParser.diceStringRegexAsString;
 
   /**
-   * Set up an save with default values and load the save result log if
+   * Set up a save with default values and load the save result log if
    * available
    */
   constructor(owner: unknown, args: EmptyObject) {
@@ -97,12 +97,13 @@ export default class RepeatedSaveFormComponent extends Component {
   }
 
   @action
-  setSaveForHalfDamage(newSaveForHalf: InputEvent) {
-    assert(
-      'save-for-half handler must receive an event with a target that is an HTMLInputElement',
-      newSaveForHalf.target instanceof HTMLInputElement,
-    );
-    this.saveForHalfDamage = newSaveForHalf.target.checked || false;
+  setNoDamageOnPassedSave() {
+    this.saveForHalfDamage = false;
+  }
+
+  @action
+  setHalfDamageOnPassedSave() {
+    this.saveForHalfDamage = true;
   }
 
   @action

--- a/tests/acceptance/repeated-save-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-save-form-with-fakes-test.ts
@@ -115,6 +115,10 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
       '#nav-saves [data-test-damage-dropdown="0"]',
       DamageType.COLD.name,
     );
+    
+    // Switch to half damage, then switch back to no damage on a passed save
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
+    await click('#nav-saves [data-test-input-passedSave-noDamage]');
 
     // Roll the saves
     await click('#nav-saves [data-test-button-rollSaves]');
@@ -217,7 +221,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
-    await click('#nav-saves [data-test-input-half-damage]');
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-roll-dmg-every-save]');
 
     // Roll the saves
@@ -322,7 +326,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await click('#nav-saves [data-test-input-vulnerable="0"]');
 
     // Add half damage on passes since all saves will pass
-    await click('#nav-saves [data-test-input-half-damage]');
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
 
     // Roll a second set of saves
     await click('#nav-saves [data-test-button-rollSaves]');
@@ -383,7 +387,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
-    await click('#nav-saves [data-test-input-half-damage]');
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-roll-dmg-every-save]');
     await click('#nav-saves [data-test-value="advantage"]');
 
@@ -479,7 +483,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
-    await click('#nav-saves [data-test-input-half-damage]');
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-roll-dmg-every-save]');
     await click('#nav-saves [data-test-value="disadvantage"]');
 

--- a/tests/acceptance/repeated-save-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-save-form-with-fakes-test.ts
@@ -27,6 +27,7 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-1D4');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '2d6');
+    await click('#nav-saves [data-test-input-passedSave-noDamage]');
 
     // Roll the saves
     await click('#nav-saves [data-test-button-rollSaves]');
@@ -115,9 +116,6 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
       '#nav-saves [data-test-damage-dropdown="0"]',
       DamageType.COLD.name,
     );
-    
-    // Switch to half damage, then switch back to no damage on a passed save
-    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-passedSave-noDamage]');
 
     // Roll the saves
@@ -221,8 +219,11 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
-    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-roll-dmg-every-save]');
+
+    // Switch away from the default half-damage passed-save behavior, then back to it
+    await click('#nav-saves [data-test-input-passedSave-noDamage]');
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
 
     // Roll the saves
     await click('#nav-saves [data-test-button-rollSaves]');
@@ -325,9 +326,6 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     // Add vulnerability
     await click('#nav-saves [data-test-input-vulnerable="0"]');
 
-    // Add half damage on passes since all saves will pass
-    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
-
     // Roll a second set of saves
     await click('#nav-saves [data-test-button-rollSaves]');
 
@@ -387,7 +385,6 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
-    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-roll-dmg-every-save]');
     await click('#nav-saves [data-test-value="advantage"]');
 
@@ -483,7 +480,6 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
     await fillIn('#nav-saves [data-test-input-saveDC]', '14');
     await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
     await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
-    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
     await click('#nav-saves [data-test-input-roll-dmg-every-save]');
     await click('#nav-saves [data-test-value="disadvantage"]');
 


### PR DESCRIPTION
Some spells or effects, like Disintegrate, inflict no damage if the target passes their save; others, like Fireball, inflict half damage even on a passed save. This PR changes the UI for handling this from a checkbox to a radio button set to make the default behavior clearer.

This PR also reverses that default behavior from "inflict no damage on a pass" to "inflict half damage on a pass" because the latter behavior feels more common among popular area-of-effect spells. In particular, the rest of the default configuration mirrors a third-level Fireball spell, which would inflict half damage on a passed save. 

Before:
![image](https://github.com/user-attachments/assets/b654c9f4-9044-44b5-ac13-021a6839519d)

After:
![image](https://github.com/user-attachments/assets/8c0ddb65-2027-49df-89d8-5cf14a62e832)
