### PR TITLE
Support evasion for targets of saves

### DIFF
--- a/app/components/repeated-save-form.hbs
+++ b/app/components/repeated-save-form.hbs
@@ -119,6 +119,22 @@
         </label>
       </div>
 
+      <div class='form-check'>
+        <input
+          data-test-input-target-has-evasion
+          class='form-check-input'
+          type='checkbox'
+          id='targetHasEvasion'
+          name='targetHasEvasion'
+          disabled={{not this.halfDamageOnPass}}
+          checked={{this.targetHasEvasion}}
+          {{on 'change' this.setTargetHasEvasion}}
+        />
+        <label class='form-check-label' for='targetHasEvasion'>
+          Target is applying evasion
+        </label>
+      </div>
+
       <hr />
 
       <DamagePane

--- a/app/components/save-damage-handling-state-enum.ts
+++ b/app/components/save-damage-handling-state-enum.ts
@@ -1,0 +1,16 @@
+export default class SaveDamageHandlingState {
+  // pass: no damage; fail: full damage
+  static NO_DAMAGE_ON_PASS = new SaveDamageHandlingState('no-damage');
+
+  // pass: half damage; fail: full damage
+  static HALF_DAMAGE_ON_PASS = new SaveDamageHandlingState('half-damage');
+
+  // pass: no damage; fail: half damage
+  static EVASION = new SaveDamageHandlingState('evasion');
+
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}

--- a/tests/acceptance/repeated-save-form-test.ts
+++ b/tests/acceptance/repeated-save-form-test.ts
@@ -284,6 +284,72 @@ module('Acceptance | repeated save form', function (hooks) {
     await click('#nav-saves [data-test-button-clear-log]');
   });
 
+  test('enabling and disabling evasion', async function (this: ElementContext, assert) {
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+
+    // Use mostly default values for the saves
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '8');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '15');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '3');
+
+    // Check that the expected default damage behavior is selected
+    assert
+      .dom('#nav-saves [data-test-input-passedSave-halfDamage]')
+      .isChecked();
+
+    // Set evasion and verify that it is checked
+    assert.dom('#nav-saves [data-test-input-target-has-evasion]').isEnabled();
+
+    await click('#nav-saves [data-test-input-target-has-evasion]');
+
+    assert
+      .dom('#nav-saves [data-test-input-target-has-evasion]')
+      .isEnabled()
+      .isChecked();
+
+    // Set no damage on passed saves
+    await click('#nav-saves [data-test-input-passedSave-noDamage]');
+    assert.dom('#nav-saves [data-test-input-passedSave-noDamage]').isChecked();
+    assert
+      .dom('#nav-saves [data-test-input-passedSave-halfDamage]')
+      .isNotChecked();
+
+    // Verify that evasion is un-checked and is disabled
+    assert
+      .dom('#nav-saves [data-test-input-target-has-evasion]')
+      .isDisabled()
+      .isNotChecked();
+
+    // Set half damage on passed saves and check that evasion is reenabled (but not checked)
+    await click('#nav-saves [data-test-input-passedSave-halfDamage]');
+    assert
+      .dom('#nav-saves [data-test-input-target-has-evasion]')
+      .isEnabled()
+      .isNotChecked();
+
+    // Execute the group of saves
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .hasText(
+        'Number of saves: 8\n' + 'Save DC: 15\n' + 'Saving throw: 1d20 + 3\n',
+        'the details for the set of saves should be displayed',
+      );
+
+    assert
+      .dom('#nav-saves [data-test-detail-list="0"]')
+      .isVisible('individual save details should be displayed');
+
+    assert.strictEqual(
+      this.element.querySelector('#nav-saves [data-test-detail-list="0"]')!
+        .children.length,
+      8,
+      '8 saves should have been displayed',
+    );
+  });
+
   test('invalidating malformatted fields', async function (this: ElementContext, assert) {
     await visit('/');
     await click('[data-test-button-saveTab]');

--- a/tests/acceptance/repeated-save-form-with-fakes-test.ts
+++ b/tests/acceptance/repeated-save-form-with-fakes-test.ts
@@ -292,6 +292,97 @@ module('Acceptance | repeated save form with fake dice', function (hooks) {
       );
   });
 
+  test('it handles evasion', async function (this: ElementContext, assert) {
+    // Mock randomness so that dice switch from maximum to minimum values
+    const fakeRandom = stubReturning(
+      0.99999999999999, // first uncached damage roll, used
+      0.99999999999999, // first d20 roll, roll 1, used
+      0.99999999999999, // first d20 roll, roll 2, ignored
+      0.5, // second uncached damage roll, used
+      0, // second d20 roll, roll 1, used
+      0, // second d20 roll, roll 2, ignored
+    );
+    const random = this.owner.lookup('service:randomness') as RandomnessService;
+    random.random = fakeRandom;
+
+    await visit('/');
+    await click('[data-test-button-saveTab]');
+    await delay();
+
+    // Fill in some details for the saves
+    await fillIn('#nav-saves [data-test-input-numberOfSaves]', '2');
+    await fillIn('#nav-saves [data-test-input-saveDC]', '14');
+    await fillIn('#nav-saves [data-test-input-saveMod]', '-2');
+    await fillIn('#nav-saves [data-test-input-damage="0"]', '1d8');
+    await click('#nav-saves [data-test-input-roll-dmg-every-save]');
+
+    // Set evasion
+    await click('#nav-saves [data-test-input-target-has-evasion]');
+
+    // Roll the saves
+    await click('#nav-saves [data-test-button-rollSaves]');
+
+    assert
+      .dom('#nav-saves [data-test-data-list="0"]')
+      .hasText(
+        'Number of saves: 2\nSave DC: 14\nSaving throw: 1d20 - 2\n',
+        'the details for the set of saves should be displayed',
+      );
+
+    // Since evasion was checked, only the failed save inflicted damage, and it
+    // inflicted only half damage
+    assert
+      .dom('#nav-saves [data-test-total-damage-header="0"]')
+      .hasText(
+        'Total Damage: 2 (1 pass)',
+        '0 + (5 / 2) damage should have been inflicted',
+      );
+
+    const detailsList = this.element.querySelector(
+      '[data-test-detail-list="0"]',
+    )!.children;
+
+    // Examine the first saving throw details
+    assert.strictEqual(
+      detailsList[0]?.className,
+      'li-success',
+      'saving throw should have bullet point formatted as a success',
+    );
+
+    // Check the saving throw text
+    assert
+      .dom(`#nav-saves [data-test-roll-detail="0-0"]`)
+      .hasAttribute('title', '1d20: 20')
+      .hasText('18 to save');
+
+    // The passed save should have no damage section
+    assert
+      .dom(`#nav-saves [data-test-damage-roll-detail="0-0-0"]`)
+      .doesNotExist();
+
+    // Examine the second saving throw details
+    assert.strictEqual(
+      detailsList[1]?.className,
+      'li-fail',
+      'saving throw should have bullet point formatted as a failure',
+    );
+
+    // Check the saving throw text
+    assert
+      .dom(`#nav-saves [data-test-roll-detail="0-1"]`)
+      .hasAttribute('title', '1d20: 1')
+      .hasText('-1 to save');
+
+    // Examine the damage section
+    assert
+      .dom(`#nav-saves [data-test-damage-roll-detail="0-1-0"]`)
+      .hasAttribute('title', '1d8: 5')
+      .hasText(
+        '2 fire damage (1d8) (evasion)',
+        'damage from the failed save should have been halved by evasion',
+      );
+  });
+
   test('it handles resistance and vulnerability', async function (this: ElementContext, assert) {
     // Mock randomness so that dice roll minimum values
     let fakeRandom = fake.returns(0);


### PR DESCRIPTION
Some D&D classes, notably monks and rogues, have the evasion feature: when they have to make a dexterity save against a spell which deals half damage on a successful save and full damage on a failed save, they instead take no damage on a failed save and half damage on a failed save. (Other things, such as the Mounted Combatant feat, can provide similar behavior.)

This adds a checkbox to indicate that every save is being rolled by a target which has evasion. This checkbox is disabled unless the spell deals half damage on a successful save, in order to partially enforce that evasion is applied as written in the D&D 5e player's handbook.

Before: 
![Screenshot 2025-07-03 195127](https://github.com/user-attachments/assets/4313fcaf-18d0-40bc-b48a-80f21f77848f)

After:
![image](https://github.com/user-attachments/assets/9ddf77d4-a3de-4990-9de8-852e37232d6f)
![image](https://github.com/user-attachments/assets/78ba650b-c1c9-457a-8f73-e817b8977cce)
![image](https://github.com/user-attachments/assets/6cc5a16e-30be-4d31-948d-80bc9d136a29)
