### PR TITLE
Revert "Bump @eslint/js from 9.39.2 to 10.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@ember/test-helpers": "^5.4.1",
         "@eslint/compat": "^2.0.2",
         "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.2",
         "@glimmer/component": "^2.0.0",
         "@glimmer/tracking": "^1.1.2",
         "@tsconfig/ember": "^3.0.12",
@@ -4272,24 +4272,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -17290,19 +17282,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@ember/test-helpers": "^5.4.1",
     "@eslint/compat": "^2.0.2",
     "@eslint/eslintrc": "^3.3.6",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.2",
     "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
     "@tsconfig/ember": "^3.0.12",


### PR DESCRIPTION
This reverts commit 41acd5dfd2a7a916d28f20e560c0d051bf220473.

Updating eslint/js without also updating eslint appears to cause dependency errors.