### PR TITLE
Revert "Bump @eslint/js from 9.39.2 to 10.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@ember/test-helpers": "^5.4.3",
         "@eslint/compat": "^2.1.0",
         "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.2",
         "@glimmer/component": "^2.1.1",
         "@glimmer/tracking": "^1.1.2",
         "@tsconfig/ember": "^3.0.12",
@@ -4265,24 +4265,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@ember/test-helpers": "^5.4.3",
     "@eslint/compat": "^2.1.0",
     "@eslint/eslintrc": "^3.3.6",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.2",
     "@glimmer/component": "^2.1.1",
     "@glimmer/tracking": "^1.1.2",
     "@tsconfig/ember": "^3.0.12",


### PR DESCRIPTION
Reverts jbpeirce/multiattack-5e#935

This causes build conflicts when trying to update Babel (and may have broken the build in general).